### PR TITLE
Rebar deps format + make sure everything builds on freebsd

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -18,8 +18,9 @@ ifeq ($(UNAME_SYS), Darwin)
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I /usr/local/include
 	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDLIBS += -L /usr/local/lib
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes

--- a/rebar.config
+++ b/rebar.config
@@ -5,10 +5,10 @@
 {minimum_otp_vsn, "17.5"}.
 
 {deps, [
-        {cowlib, {git, "https://github.com/ninenines/cowlib.git", {tag, "1.0.0"}}},
-        {gproc, {git, "https://github.com/uwiger/gproc.git", {tag, "0.5"}}},
-        {uri, {git, "https://github.com/heroku/uri.git", {branch, "master"}}},
-        {quintana, {git, "https://github.com/puzza007/quintana.git", {branch, "master"}}}
+        {cowlib, ".*",  {git, "https://github.com/ninenines/cowlib.git", {tag, "1.0.0"}}},
+        {gproc, ".*", {git, "https://github.com/uwiger/gproc.git", {tag, "0.5"}}},
+        {uri, ".*", {git, "https://github.com/heroku/uri.git", {branch, "master"}}},
+        {quintana, ".*", {git, "https://github.com/puzza007/quintana.git", {branch, "master"}}}
        ]}.
 
 {ct_opts, [{ct_hooks, [cth_readable_shell]}]}.
@@ -17,10 +17,10 @@
  [
   {test,
    [{deps,
-     [{jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}},
-      {meck, {git, "https://github.com/eproxus/meck.git", {tag, "0.8.3"}}},
-      {cth_readable, {git, "https://github.com/ferd/cth_readable.git", {branch, "master"}}},
-      {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "1.0.0"}}}
+     [{jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}},
+      {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.3"}}},
+      {cth_readable, ".*", {git, "https://github.com/ferd/cth_readable.git", {branch, "master"}}},
+      {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {tag, "1.0.0"}}}
      ]}]
   }]
 }.

--- a/rebar.config
+++ b/rebar.config
@@ -25,9 +25,11 @@
   }]
 }.
 
-{pre_hooks, [{"(linux|darwin|solaris)", compile, "make -C c_src"}]}.
+{pre_hooks, [{"(linux|darwin|solaris)", compile, "make -C c_src"},
+	     {"freebsd", compile, "gmake -C c_src"}]}.
 
-{post_hooks, [{"(linux|darwin|solaris)", clean, "make -C c_src clean"}]}.
+{post_hooks, [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
+	      {"freebsd", compile, "gmake -C c_src clean"}]}.
 
 {dialyzer, [
     {warnings, [underspecs, no_return, unmatched_returns, error_handling, unknown]},

--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,7 @@
 	     {"freebsd", compile, "gmake -C c_src"}]}.
 
 {post_hooks, [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-	      {"freebsd", compile, "gmake -C c_src clean"}]}.
+	      {"freebsd", clean, "gmake -C c_src clean"}]}.
 
 {dialyzer, [
     {warnings, [underspecs, no_return, unmatched_returns, error_handling, unknown]},


### PR DESCRIPTION
Building with elixir's mix breaks due to rebar.config deps format, update fixes it.
Call gmake on freebsd and make sure to explicitly set include and lib paths.