### PR TITLE
Fix broken HEAD request handling

### DIFF
--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -670,6 +670,7 @@ static void set_method(long method, ConnInfo *conn) {
       break;
     case KATIPO_HEAD:
       curl_easy_setopt(conn->easy, CURLOPT_CUSTOMREQUEST, "HEAD");
+      curl_easy_setopt(conn->easy, CURLOPT_NOBODY, 1);
       break;
     case KATIPO_OPTIONS:
       curl_easy_setopt(conn->easy, CURLOPT_CUSTOMREQUEST, "OPTIONS");

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -54,6 +54,7 @@ groups() ->
     [{http, [parallel],
       [get,
        get_req,
+       head,
        post_data,
        post_qs,
        post_req,
@@ -111,6 +112,10 @@ get_req(_) ->
         katipo:req(#{url => <<"http://httpbin.org/get?a=%21%40%23%24%25%5E%26%2A%28%29_%2B">>}),
     Json = jsx:decode(Body),
     [{<<"a">>, <<"!@#$%^&*()_+">>}] = proplists:get_value(<<"args">>, Json).
+
+head(_) ->
+    {ok, #{status := 200}} =
+        katipo:head(<<"http://httpbin.org/get">>).
 
 post_data(_) ->
     {ok, #{status := 200, body := Body}} =


### PR DESCRIPTION
The `HEAD` request handling was broken, because of wrong configuration of the curl request. The key is the `CURLOPT_NOBODY` option which has to be set for it. Otherwise, curl waits for request body which never comes. I have added the missing option and a test validating that it indeed works (there was no test for `HEAD` call).