### PR TITLE
Add redirect_time metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ katipo:Method(Pool :: atom(), URL :: binary(), ReqOptions :: map()).
 * connect_time
 * appconnect_time
 * pretransfer_time
+* redirect_time
 * starttransfer_time
 
 ### Dependencies

--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -71,6 +71,7 @@ typedef struct _ConnInfo {
   double connect_time;
   double appconnect_time;
   double pretransfer_time;
+  double redirect_time;
   double starttransfer_time;
 } ConnInfo;
 
@@ -363,7 +364,7 @@ static int is_status_line(const char *header) {
 }
 
 static void encode_metrics(ei_x_buff *result, ConnInfo *conn) {
-  if (ei_x_encode_list_header(result, 6)) {
+  if (ei_x_encode_list_header(result, 7)) {
     errx(2, "Failed to encode stats list header");
   }
   if (ei_x_encode_tuple_header(result, 2) ||
@@ -381,6 +382,9 @@ static void encode_metrics(ei_x_buff *result, ConnInfo *conn) {
       ei_x_encode_tuple_header(result, 2) ||
       ei_x_encode_atom(result, "pretransfer_time") ||
       ei_x_encode_double(result, conn->pretransfer_time) ||
+      ei_x_encode_tuple_header(result, 2) ||
+      ei_x_encode_atom(result, "redirect_time") ||
+      ei_x_encode_double(result, conn->redirect_time) ||
       ei_x_encode_tuple_header(result, 2) ||
       ei_x_encode_atom(result, "starttransfer_time") ||
       ei_x_encode_double(result, conn->starttransfer_time) ||
@@ -514,6 +518,7 @@ static void check_multi_info(GlobalInfo *global) {
       curl_easy_getinfo(easy, CURLINFO_CONNECT_TIME, &conn->connect_time);
       curl_easy_getinfo(easy, CURLINFO_APPCONNECT_TIME, &conn->appconnect_time);
       curl_easy_getinfo(easy, CURLINFO_PRETRANSFER_TIME, &conn->pretransfer_time);
+      curl_easy_getinfo(easy, CURLINFO_REDIRECT_TIME, &conn->redirect_time);
       curl_easy_getinfo(easy, CURLINFO_STARTTRANSFER_TIME, &conn->starttransfer_time);
 
       if (res == CURLE_OK) {

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {minimum_otp_vsn, "18.0"}.
 
 {deps, [
-        {cowlib, "1.0.0"},
+        {cowlib, "1.0.2"},
         {worker_pool, "2.3.0"},
         {metrics, "1.1.0"}
        ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,10 @@
 {"1.1.0",
-[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"1.0.0">>},0},
+[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"1.0.2">>},0},
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.1.0">>},0},
  {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"2.3.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"cowlib">>, <<"397D890D669E56D486B0B5329973AD1A07012412BC110D34A737698DD6941741">>},
+ {<<"cowlib">>, <<"9D769A1D062C9C3AC753096F868CA121E2730B9A377DE23DEC0F7E08B1DF84EE">>},
  {<<"metrics">>, <<"41450DFFBA18B1206BF44FA1AD4E29324D1E561617C2DAF4EF32E3CE50DF08F3">>},
  {<<"worker_pool">>, <<"F401FD82A6A02333F4326B144A1EE759EEDEA20411F4283A3F3195BD62A2E445">>}]}
 ].


### PR DESCRIPTION
This PR exposes the redirect_time metric from curl, and also bumps the cowlib dependency to 1.0.2.