### PR TITLE
Fix for metrics returned by return_metrics

### DIFF
--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -196,6 +196,7 @@
 -type req_body() :: iodata() | qs_vals().
 -type body() :: binary().
 -type request() :: map().
+-type metrics() :: proplists:proplist().
 -ifdef(OTP_RELEASE).
 -type response() :: {ok, #{status := status(),
                            headers := headers(),
@@ -224,6 +225,7 @@
 -export_type([req_body/0]).
 -export_type([body/0]).
 -export_type([request/0]).
+-export_type([metrics/0]).
 -export_type([response/0]).
 -export_type([http_auth/0]).
 -export_type([curlmopts/0]).
@@ -319,10 +321,9 @@ req(PoolName, Opts)
             {Result, {Response, Metrics}} =
                 wpool:call(PoolName, Req2, best_worker, infinity),
             TotalUs = timer:now_diff(os:timestamp(), Ts),
-            Response2 = maybe_return_metrics(Req2, Metrics, Response),
-            Ret = {Result, Response2},
-            ok = katipo_metrics:notify(Ret, Metrics, TotalUs),
-            Ret;
+            Metrics2 = katipo_metrics:notify({Result, Response}, Metrics, TotalUs),
+            Response2 = maybe_return_metrics(Req2, Metrics2, Response),
+            {Result, Response2};
         {error, _} = Error ->
             ok = katipo_metrics:notify_error(),
             Error

--- a/src/katipo_metrics.erl
+++ b/src/katipo_metrics.erl
@@ -4,8 +4,7 @@
 -export([notify/3]).
 -export([notify_error/0]).
 
--spec notify(katipo:response(), proplists:proplist(),
-             number()) -> ok.
+-spec notify(katipo:response(), katipo:metrics(), number()) -> katipo:metrics().
 notify({_, _} = Ret, Metrics, TotalUs) ->
     MetricsEngine = application:get_env(katipo, metrics_engine, metrics_dummy),
     notify(MetricsEngine, Ret, Metrics, TotalUs).
@@ -16,10 +15,10 @@ notify(MetricsEngine, {ok, Response}, Metrics, TotalUs) ->
     ok = metrics:increment_spiral(MetricsEngine, StatusMetric),
     OkMetric = name(ok),
     ok = metrics:increment_spiral(MetricsEngine, OkMetric),
-    ok = notify_metrics(MetricsEngine, Metrics, TotalUs);
+    notify_metrics(MetricsEngine, Metrics, TotalUs);
 notify(MetricsEngine, {error, _Error}, Metrics, TotalUs) ->
     ok = notify_error(MetricsEngine),
-    ok = notify_metrics(MetricsEngine, Metrics, TotalUs).
+    notify_metrics(MetricsEngine, Metrics, TotalUs).
 
 notify_error() ->
     MetricsEngine = application:get_env(katipo, metrics_engine, metrics_dummy),
@@ -54,7 +53,8 @@ notify_metrics(MetricsEngine, Metrics, TotalUs) ->
                      Name = name(K),
                      ok = metrics:update_histogram(MetricsEngine, Name, V)
              end,
-    ok = lists:foreach(Notify, Metrics3).
+    ok = lists:foreach(Notify, Metrics3),
+    Metrics3.
 
 -spec init() -> ok.
 init() ->

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -619,9 +619,14 @@ metrics_true(_) ->
                                        X =:= <<"katipo.starttransfer_time">> ->
                              ok
                      end),
-    {ok, #{status := 200, metrics := [_|_]}} =
+    {ok, #{status := 200, metrics := Metrics}} =
         katipo:head(?POOL, <<"http://httpbin.org/get">>, #{return_metrics => true}),
     8 = meck:num_calls(metrics, update_histogram, 3),
+    MetricKeys = [K || {K, _} <- Metrics],
+    ExpectedMetricKeys = [curl_time,total_time,namelookup_time,connect_time,
+                          appconnect_time,pretransfer_time,redirect_time,
+                          starttransfer_time],
+    true = lists:sort(MetricKeys) == lists:sort(ExpectedMetricKeys),
     meck:unload(metrics).
 
 metrics_false(_) ->


### PR DESCRIPTION
Ensure they're the same as what was sent to the metrics backend