### PR TITLE
use random_worker wpool strategy

### DIFF
--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -382,7 +382,7 @@ req(PoolName, Opts)
             Req2 = Req#req{timeout=Timeout},
             Ts = os:timestamp(),
             {Result, {Response, Metrics}} =
-                wpool:call(PoolName, Req2, best_worker, infinity),
+                wpool:call(PoolName, Req2, random_worker, infinity),
             TotalUs = timer:now_diff(os:timestamp(), Ts),
             Metrics2 = katipo_metrics:notify({Result, Response}, Metrics, TotalUs),
             Response2 = maybe_return_metrics(Req2, Metrics2, Response),


### PR DESCRIPTION
Performing load tests, I saw a bottleneck in wpool strategy reparting load on only on katipo thread. `random_worker` strategy makes a better repartition of load and improve performances.