### PR TITLE
Restrict protocols to HTTP(S)

### DIFF
--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -758,6 +758,10 @@ static void new_conn(long method, char *url, struct curl_slist *req_headers,
   conn->post_data = post_data;
   conn->post_data_size = post_data_size;
 
+  curl_easy_setopt(conn->easy, CURLOPT_PROTOCOLS,
+                   CURLPROTO_HTTP | CURLPROTO_HTTPS);
+  curl_easy_setopt(conn->easy, CURLOPT_REDIR_PROTOCOLS,
+                   CURLPROTO_HTTP | CURLPROTO_HTTPS);
   curl_easy_setopt(conn->easy, CURLOPT_URL, conn->url);
   curl_easy_setopt(conn->easy, CURLOPT_HTTPHEADER, conn->req_headers);
   if (eopts.curlopt_http_version) {

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -142,7 +142,8 @@ groups() ->
        lock_data_ssl_session_false,
        doh_url,
        badopts,
-       proxy_couldnt_connect]},
+       proxy_couldnt_connect,
+       protocol_restriction]},
      {pool, [],
       [pool_start_stop,
        worker_death,
@@ -537,6 +538,9 @@ proxy_couldnt_connect(_) ->
     Url = <<"https://httpbin.org/get">>,
     {error, #{code := couldnt_connect}} =
         katipo:get(?POOL, Url, #{proxy => <<"http://localhost:3128">>}).
+
+protocol_restriction(_) ->
+    {error, #{code := unsupported_protocol}} = katipo:get(?POOL, <<"dict.org">>).
 
 timeout_ms(_) ->
     {error, #{code := operation_timedout}} =


### PR DESCRIPTION
We don't support any other protocols e.g. DICT

❯ curl dict.org
220 dict.dict.org dictd 1.12.1/rf on Linux 4.19.0-10-amd64 <auth.mime> <25642111.19589.1617608512@dict.dict.org>
250 ok
221 bye [d/m/c = 0/0/0; 0.000r 0.000u 0.000s]