### PR TITLE
shutdown pool supervisor gracefully

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
    [{deps,
      [{jsx, "2.9.0"},
       {meck, "0.8.10"},
-      {cowboy, "2.6.3"},
+      {cowboy, "2.9.0"},
       {ephemeral, "2.0.4"},
       {http_proxy, ".*", {git, "https://github.com/puzza007/http_proxy.git", {branch, "rebar3"}}},
       {proper, "1.3.0"}

--- a/src/katipo_pool.erl
+++ b/src/katipo_pool.erl
@@ -20,7 +20,8 @@ start(PoolName, PoolSize, WorkerOpts)
     Args = [WorkerOpts],
 
     PoolOpts = [{worker, {katipo, Args}},
-                {workers, PoolSize}],
+                {workers, PoolSize},
+                {pool_sup_shutdown, infinity}],
 
     wpool:start_sup_pool(PoolName, PoolOpts).
 


### PR DESCRIPTION
The default is `brutal_kill` which causes a bunch of unpleasant crash reports

Repro: 
```
$ rebar3 shell
...
> katipo_pool:start(test, 2).
> katipo_pool:stop(test).
```