### PR TITLE
Remove http proxy tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,6 @@
       {meck, "0.8.10"},
       {cowboy, "2.9.0"},
       {ephemeral, "2.0.4"},
-      {http_proxy, ".*", {git, "https://github.com/puzza007/http_proxy.git", {branch, "rebar3"}}},
       {proper, "1.3.0"}
      ]}]
   }]


### PR DESCRIPTION
The library used to spin up a temp proxy isn't compatible with OTP
24 (pg and gen_statem).

I may add them back later when I move off Travis CI.