### PR TITLE
Upgrade worker_pool library to version 6.0.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {minimum_otp_vsn, "23.0"}.
 
 {deps, [
-        {worker_pool, "6.0.0"},
+        {worker_pool, "6.0.1"},
         {metrics, "2.5.0"}
        ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,11 @@
 {"1.2.0",
 [{<<"metrics">>,{pkg,<<"metrics">>,<<"2.5.0">>},0},
- {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"6.0.0">>},0}]}.
+ {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"6.0.1">>},0}]}.
 [
 {pkg_hash,[
  {<<"metrics">>, <<"268D218D56529CB5F070D74BBFC3AF64C668379B5B18FAFDA88959442F790C57">>},
- {<<"worker_pool">>, <<"F7B442B30121EED6D8C828833533E5C15DB61E4AB2EF343C8B67824267656822">>}]},
+ {<<"worker_pool">>, <<"CA262C2DFB3B4AF661B206C82065D86F83922B7227508AA6E0BC34D3E5AE5135">>}]},
 {pkg_hash_ext,[
  {<<"metrics">>, <<"AE061938C8C3BDE97D17BE9A792B63E15C1E1EFFE16598AB87A62384F5F3714B">>},
- {<<"worker_pool">>, <<"F9D95B85E80C5C27B7AB2E60BF780DA70A5E26DD9E6D30BE45032742FC039CC5">>}]}
+ {<<"worker_pool">>, <<"772E12CCB26909EA7F804B52E86E733DF66BB8150F683B591B0A762196494C74">>}]}
 ].


### PR DESCRIPTION
Hi,

I have seen that when upgrading `worker_pool` to version 6.0.1, dialyzer stops complaining about no local returns in 

```
src/katipo_pool.erl
Line 11 Column 1: Function start/2 has no local return
Line 16 Column 1: Function start/3 has no local return
```

I know that this warning is disabled in the project but this way users will not have to disable it in theirs when using katipo