### PR TITLE
feat: migrate from edoc to ex_doc

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -57,6 +57,7 @@
                deprecated_functions]}.
 
 {plugins, [rebar3_hex,
+           rebar3_ex_doc,
            {rebar3_lint, "4.1.1"},
            {covertool, "2.0.6"},
            {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {tag, "0.3.0"}}}
@@ -65,4 +66,14 @@
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["ct.coverdata"]}]}.
 
-{hex, [{doc, #{provider => edoc}}]}.
+{hex, [{doc, #{provider => ex_doc}}]}.
+
+{ex_doc, [
+    {extras, [
+        {"README.md", #{title => "Overview"}},
+        {"LICENSE", #{title => "License"}}
+    ]},
+    {main, "README.md"},
+    {homepage_url, "https://github.com/puzza007/katipo"},
+    {source_url, "https://github.com/puzza007/katipo"}
+]}.

--- a/src/katipo_app.erl
+++ b/src/katipo_app.erl
@@ -1,4 +1,5 @@
 -module(katipo_app).
+-moduledoc false.
 
 -behaviour(application).
 

--- a/src/katipo_metrics.erl
+++ b/src/katipo_metrics.erl
@@ -1,5 +1,5 @@
-%% @hidden
 -module(katipo_metrics).
+-moduledoc false.
 
 -include_lib("opentelemetry_api_experimental/include/otel_meter.hrl").
 
@@ -74,7 +74,6 @@ notify({error, _Error}, Metrics, TotalUs, Method) ->
     notify_timing_metrics(Metrics, TotalUs, Method).
 
 
-%% @private
 notify_timing_metrics(Metrics, TotalUs, Method) ->
     %% Curl metrics are in seconds, convert to milliseconds
     Metrics1 = [{K, 1000 * V} || {K, V} <- Metrics],
@@ -92,7 +91,6 @@ notify_timing_metrics(Metrics, TotalUs, Method) ->
     lists:foreach(fun({K, V}) -> record_timing(K, V, Attrs) end, Metrics3),
     Metrics3.
 
-%% @private
 record_timing(total_time, V, Attrs) ->
     try ?histogram_record(?DURATION_HISTOGRAM, V, Attrs) catch error:undef -> ok end;
 record_timing(curl_time, V, Attrs) ->

--- a/src/katipo_pool.erl
+++ b/src/katipo_pool.erl
@@ -1,4 +1,5 @@
 -module(katipo_pool).
+-moduledoc "Manages pools of katipo HTTP client workers.".
 
 -export([start/2]).
 -export([start/3]).
@@ -7,10 +8,12 @@
 -type name() :: atom().
 -export_type([name/0]).
 
+-doc #{equiv => start/3}.
 -spec start(name(), pos_integer()) -> supervisor:startchild_ret().
 start(PoolName, PoolSize) ->
     start(PoolName, PoolSize, []).
 
+-doc "Starts a named pool of katipo workers with the given size and curl multi options.".
 -spec start(name(), pos_integer(), katipo:curlmopts()) ->
                    supervisor:startchild_ret().
 start(PoolName, PoolSize, WorkerOpts)
@@ -25,6 +28,7 @@ start(PoolName, PoolSize, WorkerOpts)
 
     wpool:start_sup_pool(PoolName, PoolOpts).
 
+-doc "Stops a named pool.".
 -spec stop(name()) -> ok.
 stop(PoolName) when is_atom(PoolName) ->
     wpool:stop_sup_pool(PoolName).

--- a/src/katipo_sup.erl
+++ b/src/katipo_sup.erl
@@ -1,5 +1,5 @@
-%% @hidden
 -module(katipo_sup).
+-moduledoc false.
 
 -behaviour(supervisor).
 


### PR DESCRIPTION
## Summary
- Replace edoc with ex_doc (via rebar3_ex_doc) for modern, searchable hex docs
- Add OTP 27 `-moduledoc` and `-doc` attributes to all modules
- Replace `%% @private` / `%% @equiv` comments with `-doc false` / `-doc #{equiv => ...}`
- Hide internal modules (katipo_app, katipo_sup, katipo_metrics) from generated docs
- Include README and LICENSE as extra pages

## Test plan
- [x] `rebar3 compile` passes
- [x] `rebar3 ex_doc` generates docs successfully
- [ ] CI passes