### PR TITLE
feat: add async API for non-blocking HTTP requests

### DIFF
--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -1305,7 +1305,6 @@ static void erl_input(struct bufferevent *ev, void *arg) {
         ei_decode_ref(buf, &index, ref)) {
       goto cleanup;
     }
-    have_identity = 1;
 
     /* Cancel command: {Pid, Ref, cancel} (arity 3). Abort the matching
      * in-flight transfer if we still have it; no response is sent. Requests
@@ -1322,6 +1321,10 @@ static void erl_input(struct bufferevent *ev, void *arg) {
         ei_get_type(buf, &index, &erl_type, &size)) {
       goto cleanup;
     }
+    /* Only now do we consider the identity usable for a parse-error reply:
+     * a request with an undecodable method is dropped silently (have_identity
+     * stays 0), matching the behaviour before cancellation was added. */
+    have_identity = 1;
 
     url = (char *)malloc(size + 1);
     if (ei_decode_binary(buf, &index, url, &sizel)) {

--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -68,6 +68,9 @@ typedef struct _GlobalInfo {
   curl_version_info_data *ver;
   struct bufferevent *to_erlang;
   struct bufferevent *from_erlang;
+  /* Intrusive list of in-flight transfers so a cancel can find and abort a
+   * specific request by its {pid, ref} identity. */
+  struct _ConnInfo *active_conns;
 } GlobalInfo;
 
 typedef struct _ConnInfo {
@@ -95,6 +98,7 @@ typedef struct _ConnInfo {
   double pretransfer_time;
   double redirect_time;
   double starttransfer_time;
+  struct _ConnInfo *prev, *next; /* GlobalInfo.active_conns list links */
 } ConnInfo;
 
 typedef struct _SockInfo {
@@ -555,6 +559,56 @@ static void send_error_to_erlang(CURLcode curl_code, ConnInfo *conn) {
   ei_x_free(&result);
 }
 
+static void register_conn(GlobalInfo *global, ConnInfo *conn) {
+  conn->prev = NULL;
+  conn->next = global->active_conns;
+  if (conn->next) {
+    conn->next->prev = conn;
+  }
+  global->active_conns = conn;
+}
+
+/* O(1) removal thanks to the prev link; no head-to-node scan. */
+static void unlink_conn(GlobalInfo *global, ConnInfo *conn) {
+  if (conn->prev) {
+    conn->prev->next = conn->next;
+  } else {
+    global->active_conns = conn->next;
+  }
+  if (conn->next) {
+    conn->next->prev = conn->prev;
+  }
+}
+
+/* Remove a transfer from the multi handle and free everything it owns.
+ * Shared by normal completion and cancellation. */
+static void free_conn(GlobalInfo *global, ConnInfo *conn) {
+  unlink_conn(global, conn);
+  curl_multi_remove_handle(global->multi, conn->easy);
+  free(conn->url);
+  free(conn->pid);
+  free(conn->ref);
+  free(conn->memory);
+  free(conn->post_data);
+  curl_slist_free_all(conn->req_cookies);
+  curl_slist_free_all(conn->req_headers);
+  curl_slist_free_all(conn->resp_headers);
+  curl_easy_cleanup(conn->easy);
+  free(conn);
+}
+
+/* Abort the in-flight transfer matching {pid, ref}, if we still have it. No
+ * response is sent to Erlang -- the request is simply dropped. A no-op if the
+ * request already completed (already removed from active_conns). */
+static void cancel_conn(GlobalInfo *global, erlang_pid *pid, erlang_ref *ref) {
+  for (ConnInfo *conn = global->active_conns; conn; conn = conn->next) {
+    if (ei_cmp_refs(conn->ref, ref) == 0 && ei_cmp_pids(conn->pid, pid) == 0) {
+      free_conn(global, conn);
+      return;
+    }
+  }
+}
+
 static void check_multi_info(GlobalInfo *global) {
   CURLMsg *msg;
   int msgs_left;
@@ -582,17 +636,7 @@ static void check_multi_info(GlobalInfo *global) {
         send_error_to_erlang(res, conn);
       }
 
-      curl_multi_remove_handle(global->multi, easy);
-      free(conn->url);
-      free(conn->pid);
-      free(conn->ref);
-      free(conn->memory);
-      free(conn->post_data);
-      curl_slist_free_all(conn->req_cookies);
-      curl_slist_free_all(conn->req_headers);
-      curl_slist_free_all(conn->resp_headers);
-      curl_easy_cleanup(easy);
-      free(conn);
+      free_conn(global, conn);
     }
   }
 }
@@ -794,6 +838,7 @@ static void new_conn(long method, char *url, struct curl_slist *req_headers,
     errx(2, "curl_easy_init() failed, exiting!\n");
   }
   conn->global = global;
+  register_conn(global, conn);
   conn->url = url;
   conn->pid = pid;
   conn->ref = ref;
@@ -1257,12 +1302,26 @@ static void erl_input(struct bufferevent *ev, void *arg) {
     if (ei_decode_version(buf, &index, &version) ||
         ei_decode_tuple_header(buf, &index, &arity) ||
         ei_decode_pid(buf, &index, pid) ||
-        ei_decode_ref(buf, &index, ref) ||
-        ei_decode_long(buf, &index, &method) ||
-        ei_get_type(buf, &index, &erl_type, &size)) {
+        ei_decode_ref(buf, &index, ref)) {
       goto cleanup;
     }
     have_identity = 1;
+
+    /* Cancel command: {Pid, Ref, cancel} (arity 3). Abort the matching
+     * in-flight transfer if we still have it; no response is sent. Requests
+     * are 8-tuples, so arity discriminates the two. */
+    if (arity == 3) {
+      cancel_conn(global, pid, ref);
+      free(pid);
+      free(ref);
+      free(buf);
+      continue;
+    }
+
+    if (ei_decode_long(buf, &index, &method) ||
+        ei_get_type(buf, &index, &erl_type, &size)) {
+      goto cleanup;
+    }
 
     url = (char *)malloc(size + 1);
     if (ei_decode_binary(buf, &index, url, &sizel)) {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/src/katipo.app.src
+++ b/src/katipo.app.src
@@ -1,6 +1,6 @@
 {application, 'katipo',
  [{description, "HTTP client based on libcurl"},
-  {vsn, "2.0.0-rc.1"},
+  {vsn, "2.0.0-rc.2"},
   {registered, []},
   {mod, {'katipo_app', []}},
   {applications,

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -44,7 +44,10 @@ If the pool worker handling an in-flight async request dies (e.g. its port
 crashes), a `{katipo_error, Ref, #{code => worker_died}}` message is delivered
 so the caller fails fast instead of blocking until the request timeout.
 
-Note: async requests do not currently emit OTel spans or metrics.
+Async requests emit the same OTel span (`HTTP <METHOD>`, parented to the
+caller's context) and metrics as their synchronous counterparts; the span
+covers the full request and is finished when the response, a timeout, or a
+worker failure arrives.
 """.
 
 -behaviour(gen_server).
@@ -742,12 +745,28 @@ async_req(PoolName, Opts)
             case build_req(Opts2) of
                 {ok, Req} ->
                     UserRef = make_ref(),
-                    wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req}, random_worker),
+                    Obs = start_async_obs(Req),
+                    wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req, Obs},
+                               random_worker),
                     {ok, UserRef};
                 {error, _} = Error ->
                     Error
             end
     end.
+
+%% @private
+%% Start the OTel span (parented to the caller's context so the async request
+%% appears under the caller's trace) and capture what the worker needs to emit
+%% metrics and finish the span when the response arrives. Mirrors the sync
+%% observability in do_req_with_span/2, but split across processes.
+start_async_obs(#req{method = MethodInt, url = Url}) ->
+    Method = method_int_to_binary(MethodInt),
+    SpanName = <<"HTTP ", Method/binary>>,
+    SpanCtx = otel_tracer:start_span(otel_ctx:get_current(),
+                                     opentelemetry:get_application_tracer(?MODULE),
+                                     SpanName, #{kind => client}),
+    set_request_span_attrs(SpanCtx, Method, Url),
+    #{method => Method, ts => os:timestamp(), span => SpanCtx}.
 
 -doc #{equiv => await/2}.
 -spec await(reference()) -> response().
@@ -811,37 +830,49 @@ do_req_with_span(PoolName, Req) ->
     Method = method_int_to_binary(MethodInt),
     SpanName = <<"HTTP ", Method/binary>>,
     ?with_span(SpanName, #{kind => client}, fun(SpanCtx) ->
-        %% Only parse URL and set attributes if span is actually recording
-        %% (avoids overhead when OTel SDK is not configured)
-        case otel_span:is_recording(SpanCtx) of
-            true ->
-                ?set_attribute('http.request.method', Method),
-                set_url_span_attrs(Url);
-            false ->
-                ok
-        end,
+        set_request_span_attrs(SpanCtx, Method, Url),
         Ts = os:timestamp(),
         {Result, {Response, Metrics}} =
             wpool:call(PoolName, Req, random_worker, infinity),
-        TotalUs = timer:now_diff(os:timestamp(), Ts),
-        %% Set span attributes based on response
-        set_response_span_attrs(Result, Response),
-        _ = katipo_metrics:notify({Result, Response}, Metrics, TotalUs, Method),
+        record_outcome(SpanCtx, Method, Ts, Result, Response, Metrics),
         {Result, Response}
     end).
 
 -doc false.
-set_response_span_attrs(ok, #{status := Status}) ->
-    ?set_attribute('http.response.status_code', Status),
+%% Set the request span attributes (method + sanitized URL), only when the span
+%% is recording (URL parsing is skipped otherwise). Shared by the sync and async
+%% start paths.
+set_request_span_attrs(SpanCtx, Method, Url) ->
+    case otel_span:is_recording(SpanCtx) of
+        true ->
+            otel_span:set_attribute(SpanCtx, 'http.request.method', Method),
+            set_url_span_attrs(SpanCtx, Url);
+        false ->
+            ok
+    end.
+
+-doc false.
+%% Set response span attributes and emit request metrics -- the shared tail of
+%% both the sync request (do_req_with_span/2) and an async request completing in
+%% the worker (finish_async_obs/4).
+record_outcome(SpanCtx, Method, Ts, Result, Response, Metrics) ->
+    TotalUs = timer:now_diff(os:timestamp(), Ts),
+    set_response_span_attrs(SpanCtx, Result, Response),
+    _ = katipo_metrics:notify({Result, Response}, Metrics, TotalUs, Method),
+    ok.
+
+-doc false.
+set_response_span_attrs(SpanCtx, ok, #{status := Status}) ->
+    otel_span:set_attribute(SpanCtx, 'http.response.status_code', Status),
     case Status >= 400 of
-        true -> ?set_status(error, <<>>);
+        true -> otel_span:set_status(SpanCtx, error, <<>>);
         false -> ok
     end;
-set_response_span_attrs(error, #{code := Code, message := _Msg}) ->
+set_response_span_attrs(SpanCtx, error, #{code := Code, message := _Msg}) ->
     %% Don't include error message in span - it may contain sensitive URL info
-    ?set_status(error, <<>>),
-    ?set_attribute('error.type', Code);
-set_response_span_attrs(_, _) ->
+    otel_span:set_status(SpanCtx, error, <<>>),
+    otel_span:set_attribute(SpanCtx, 'error.type', Code);
+set_response_span_attrs(_SpanCtx, _, _) ->
     ok.
 
 -doc false.
@@ -854,13 +885,13 @@ method_int_to_binary(?PATCH) -> <<"PATCH">>;
 method_int_to_binary(?DELETE) -> <<"DELETE">>.
 
 -doc false.
-set_url_span_attrs(Url) ->
+set_url_span_attrs(SpanCtx, Url) ->
     case parse_url_for_span(Url) of
         {<<>>, _} ->
             ok;
         {SanitizedUrl, Host} ->
-            ?set_attribute('url.full', SanitizedUrl),
-            ?set_attribute('server.address', Host)
+            otel_span:set_attribute(SpanCtx, 'url.full', SanitizedUrl),
+            otel_span:set_attribute(SpanCtx, 'server.address', Host)
     end.
 
 -doc false.
@@ -906,12 +937,12 @@ handle_call(Req = #req{timeout = Timeout}, From, State = #state{port = Port, req
     {noreply, State#state{reqs = Reqs2}}.
 
 -doc false.
-handle_cast({async_req, ReplyTo, UserRef, Req = #req{timeout = Timeout}},
+handle_cast({async_req, ReplyTo, UserRef, Req = #req{timeout = Timeout}, Obs},
             State = #state{port = Port, reqs = Reqs}) ->
     InternalFrom = {self(), make_ref()},
     send_to_port(Port, InternalFrom, Req),
     Tref = erlang:start_timer(Timeout, self(), {req_timeout, InternalFrom}),
-    Reqs2 = Reqs#{InternalFrom => {Tref, {async, ReplyTo, UserRef}}},
+    Reqs2 = Reqs#{InternalFrom => {Tref, {async, ReplyTo, UserRef, Obs}}},
     {noreply, State#state{reqs = Reqs2}};
 handle_cast({cancel, UserRef}, State = #state{port = Port, reqs = Reqs}) ->
     %% Broadcast reaches every worker; only the one holding this request acts.
@@ -926,9 +957,10 @@ handle_cast(Msg, State) ->
 %% async ReplyTo (via a flattened katipo_response/katipo_error message).
 deliver(sync, From, Result, Response) ->
     gen_server:reply(From, {Result, Response});
-deliver({async, ReplyTo, UserRef}, _From, Result, {ResponseMap, _Metrics}) ->
+deliver({async, ReplyTo, UserRef, Obs}, _From, Result, {ResponseMap, Metrics}) ->
     Tag = case Result of ok -> katipo_response; error -> katipo_error end,
-    ReplyTo ! {Tag, UserRef, ResponseMap}.
+    ReplyTo ! {Tag, UserRef, ResponseMap},
+    finish_async_obs(Obs, Result, ResponseMap, Metrics).
 
 -doc false.
 %% Deliver a request timeout to a sync caller or an async ReplyTo.
@@ -939,8 +971,9 @@ deliver_timeout(Kind, From) ->
 %% reply_to (as a katipo_error message).
 deliver_error(sync, From, Error) ->
     gen_server:reply(From, {error, {Error, []}});
-deliver_error({async, ReplyTo, UserRef}, _From, Error) ->
-    ReplyTo ! {katipo_error, UserRef, Error}.
+deliver_error({async, ReplyTo, UserRef, Obs}, _From, Error) ->
+    ReplyTo ! {katipo_error, UserRef, Error},
+    finish_async_obs(Obs, error, Error, []).
 
 -doc false.
 handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
@@ -994,9 +1027,24 @@ terminate(_Reason, #state{port = Port, reqs = Reqs}) ->
     end,
     ok.
 
-notify_worker_died(From, {_Tref, {async, _, _} = Kind}) ->
+notify_worker_died(From, {_Tref, {async, _, _, _} = Kind}) ->
     deliver_error(Kind, From, #{code => worker_died, message => <<>>});
 notify_worker_died(_From, {_Tref, sync}) ->
+    ok.
+
+%% Emit metrics and finish the OTel span for a completed async request. Mirrors
+%% the tail of do_req_with_span/2, but runs in the worker when the response
+%% (or timeout/worker-death) arrives rather than in the calling process.
+finish_async_obs(Obs = #{method := Method, ts := Ts, span := SpanCtx},
+                 Result, Response, Metrics) ->
+    record_outcome(SpanCtx, Method, Ts, Result, Response, Metrics),
+    end_obs(Obs).
+
+%% End the OTel span for an async request. Every terminal path (completion,
+%% timeout, worker death, cancel) calls this exactly once, alongside removing
+%% the request from the reqs map.
+end_obs(#{span := SpanCtx}) ->
+    _ = otel_span:end_span(SpanCtx),
     ok.
 
 %% Cancel the async request with this user Ref, if this worker holds it: tell
@@ -1004,18 +1052,19 @@ notify_worker_died(_From, {_Tref, sync}) ->
 %% no response is delivered.
 cancel_async(Port, UserRef, Reqs) ->
     case find_async(UserRef, Reqs) of
-        {ok, {Self, Ref} = From, Tref} ->
+        {ok, {Self, Ref} = From, Tref, Obs} ->
             _ = erlang:cancel_timer(Tref),
             true = port_command(Port, term_to_binary({Self, Ref, cancel})),
+            end_obs(Obs),
             maps:remove(From, Reqs);
         error ->
             Reqs
     end.
 
 find_async(UserRef, Reqs) ->
-    case [{From, Tref}
-          || From := {Tref, {async, _ReplyTo, UR}} <- Reqs, UR =:= UserRef] of
-        [{From, Tref} | _] -> {ok, From, Tref};
+    case [{From, Tref, Obs}
+          || From := {Tref, {async, _ReplyTo, UR, Obs}} <- Reqs, UR =:= UserRef] of
+        [{From, Tref, Obs} | _] -> {ok, From, Tref, Obs};
         [] -> error
     end.
 

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -704,9 +704,7 @@ async_delete(PoolName, Url, Opts) ->
 -spec req(katipo_pool:name(), request()) -> response().
 req(PoolName, Opts)
   when is_map(Opts) ->
-    case process_opts(Opts) of
-        {ok, #req{url = undefined}} ->
-            {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
+    case build_req(Opts) of
         {ok, Req} ->
             do_req_with_span(PoolName, Req);
         {error, _} = Error ->
@@ -725,20 +723,19 @@ Use `await/1,2` to block until the response arrives.
 -spec async_req(katipo_pool:name(), request()) -> async_response().
 async_req(PoolName, Opts)
   when is_map(Opts) ->
-    ReplyTo = maps:get(reply_to, Opts, self()),
+    {ReplyTo, Opts2} =
+        case maps:take(reply_to, Opts) of
+            {RT, Rest} -> {RT, Rest};
+            error -> {self(), Opts}
+        end,
     case is_pid(ReplyTo) of
         false ->
             {error, error_map(bad_opts, <<"[{reply_to,invalid}]">>)};
         true ->
-            Opts2 = maps:remove(reply_to, Opts),
-            case process_opts(Opts2) of
-                {ok, #req{url = undefined}} ->
-                    {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
+            case build_req(Opts2) of
                 {ok, Req} ->
                     UserRef = make_ref(),
-                    Timeout = ?MODULE:get_timeout(Req),
-                    Req2 = Req#req{timeout = Timeout},
-                    wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req2}, random_worker),
+                    wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req}, random_worker),
                     {ok, UserRef};
                 {error, _} = Error ->
                     Error
@@ -770,6 +767,20 @@ await(Ref, Timeout) ->
     end.
 
 -doc false.
+%% Build a validated, timeout-stamped #req{} from an opts map. Shared by the
+%% sync req/2 and async_req/2 entry points.
+-spec build_req(request()) -> {ok, req()} | {error, map()}.
+build_req(Opts) ->
+    case process_opts(Opts) of
+        {ok, #req{url = undefined}} ->
+            {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
+        {ok, Req} ->
+            {ok, Req#req{timeout = ?MODULE:get_timeout(Req)}};
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc false.
 do_req_with_span(PoolName, Req) ->
     #req{method = MethodInt, url = Url} = Req,
     Method = method_int_to_binary(MethodInt),
@@ -784,11 +795,9 @@ do_req_with_span(PoolName, Req) ->
             false ->
                 ok
         end,
-        Timeout = ?MODULE:get_timeout(Req),
-        Req2 = Req#req{timeout = Timeout},
         Ts = os:timestamp(),
         {Result, {Response, Metrics}} =
-            wpool:call(PoolName, Req2, random_worker, infinity),
+            wpool:call(PoolName, Req, random_worker, infinity),
         TotalUs = timer:now_diff(os:timestamp(), Ts),
         %% Set span attributes based on response
         set_response_span_attrs(Result, Response),
@@ -868,7 +877,7 @@ init([CurlOpts]) ->
 handle_call(Req = #req{timeout = Timeout}, From, State = #state{port = Port, reqs = Reqs}) ->
     send_to_port(Port, From, Req),
     Tref = erlang:start_timer(Timeout, self(), {req_timeout, From}),
-    Reqs2 = Reqs#{From => Tref},
+    Reqs2 = Reqs#{From => {Tref, sync}},
     {noreply, State#state{reqs = Reqs2}}.
 
 -doc false.
@@ -882,6 +891,26 @@ handle_cast({async_req, ReplyTo, UserRef, Req = #req{timeout = Timeout}},
 handle_cast(Msg, State) ->
     logger:error("Unexpected cast: ~p", [Msg]),
     {noreply, State}.
+
+-doc false.
+%% Deliver a completed response to a sync caller (via gen_server:reply) or an
+%% async ReplyTo (via a flattened katipo_response/katipo_error message).
+deliver(sync, From, Result, Response) ->
+    gen_server:reply(From, {Result, Response});
+deliver({async, ReplyTo, UserRef}, _From, Result, {ResponseMap, _Metrics}) ->
+    Tag = case Result of ok -> katipo_response; error -> katipo_error end,
+    ReplyTo ! {Tag, UserRef, ResponseMap}.
+
+-doc false.
+%% Deliver a request timeout to a sync caller or an async ReplyTo.
+deliver_timeout(Kind, From) ->
+    Error = #{code => operation_timedout, message => <<>>},
+    case Kind of
+        sync ->
+            gen_server:reply(From, {error, {Error, []}});
+        {async, ReplyTo, UserRef} ->
+            ReplyTo ! {katipo_error, UserRef, Error}
+    end.
 
 -doc false.
 handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
@@ -898,18 +927,9 @@ handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
                 {error, {From0, {Error, Metrics}}}
         end,
     _ = case maps:find(From, Reqs) of
-        {ok, Tref} when is_reference(Tref) ->
-            %% Sync path
+        {ok, {Tref, Kind}} ->
             _ = erlang:cancel_timer(Tref),
-            gen_server:reply(From, {Result, Response});
-        {ok, {Tref, {async, ReplyTo, UserRef}}} ->
-            %% Async path — flatten into separate ok/error messages
-            {ResponseMap, _Metrics} = Response,
-            _ = erlang:cancel_timer(Tref),
-            case Result of
-                ok    -> ReplyTo ! {katipo_response, UserRef, ResponseMap};
-                error -> ReplyTo ! {katipo_error, UserRef, ResponseMap}
-            end;
+            deliver(Kind, From, Result, Response);
         error ->
             ok
     end,
@@ -918,18 +938,10 @@ handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
 handle_info({timeout, Tref, {req_timeout, From}}, State = #state{reqs = Reqs}) ->
     Reqs2 =
         case maps:find(From, Reqs) of
-            {ok, Tref} when is_reference(Tref) ->
-                %% Sync path
-                Error = #{code => operation_timedout, message => <<>>},
-                Metrics = [],
-                _ = gen_server:reply(From, {error, {Error, Metrics}}),
+            {ok, {Tref, Kind}} ->
+                _ = deliver_timeout(Kind, From),
                 maps:remove(From, Reqs);
-            {ok, {Tref, {async, ReplyTo, UserRef}}} ->
-                %% Async path
-                Error = #{code => operation_timedout, message => <<>>},
-                _ = ReplyTo ! {katipo_error, UserRef, Error},
-                maps:remove(From, Reqs);
-            error ->
+            _ ->
                 Reqs
         end,
     {noreply, State#state{reqs = Reqs2}};

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -877,11 +877,11 @@ handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
                 Error = #{code => Code, message => Message},
                 {error, {From0, {Error, Metrics}}}
         end,
-    case maps:find(From, Reqs) of
+    _ = case maps:find(From, Reqs) of
         {ok, Tref} when is_reference(Tref) ->
             %% Sync path
             _ = erlang:cancel_timer(Tref),
-            _ = gen_server:reply(From, {Result, Response});
+            gen_server:reply(From, {Result, Response});
         {ok, {Tref, {async, ReplyTo, UserRef}}} ->
             %% Async path — flatten into separate ok/error messages
             {ResponseMap, _Metrics} = Response,
@@ -907,7 +907,7 @@ handle_info({timeout, Tref, {req_timeout, From}}, State = #state{reqs = Reqs}) -
             {ok, {Tref, {async, ReplyTo, UserRef}}} ->
                 %% Async path
                 Error = #{code => operation_timedout, message => <<>>},
-                ReplyTo ! {katipo_error, UserRef, Error},
+                _ = ReplyTo ! {katipo_error, UserRef, Error},
                 maps:remove(From, Reqs);
             error ->
                 Reqs

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -39,6 +39,10 @@ by the `reply_to` option):
 
 Use `await/1,2` to block until the response arrives.
 
+If the pool worker handling an in-flight async request dies (e.g. its port
+crashes), a `{katipo_error, Ref, #{code => worker_died}}` message is delivered
+so the caller fails fast instead of blocking until the request timeout.
+
 Note: async requests do not currently emit OTel spans or metrics.
 """.
 
@@ -322,7 +326,8 @@ Note: async requests do not currently emit OTel spans or metrics.
         curl_last |
         %% returned by us, not curl
         bad_opts |
-        await_timeout.
+        await_timeout |
+        worker_died.
 
 -type curlmopt() ::
         max_total_connections |
@@ -904,13 +909,14 @@ deliver({async, ReplyTo, UserRef}, _From, Result, {ResponseMap, _Metrics}) ->
 -doc false.
 %% Deliver a request timeout to a sync caller or an async ReplyTo.
 deliver_timeout(Kind, From) ->
-    Error = #{code => operation_timedout, message => <<>>},
-    case Kind of
-        sync ->
-            gen_server:reply(From, {error, {Error, []}});
-        {async, ReplyTo, UserRef} ->
-            ReplyTo ! {katipo_error, UserRef, Error}
-    end.
+    deliver_error(Kind, From, #{code => operation_timedout, message => <<>>}).
+
+%% Deliver an error map to a sync caller (as a gen_server reply) or an async
+%% reply_to (as a katipo_error message).
+deliver_error(sync, From, Error) ->
+    gen_server:reply(From, {error, {Error, []}});
+deliver_error({async, ReplyTo, UserRef}, _From, Error) ->
+    ReplyTo ! {katipo_error, UserRef, Error}.
 
 -doc false.
 handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
@@ -950,8 +956,23 @@ handle_info({'EXIT', Port, Reason}, State = #state{port = Port}) ->
     {stop, port_died, State}.
 
 -doc false.
-terminate(_Reason, #state{port = Port}) ->
-    true = port_close(Port),
+terminate(_Reason, #state{port = Port, reqs = Reqs}) ->
+    %% The worker is going away (typically because its port died) with
+    %% requests still in flight. Sync callers are covered by wpool:call's
+    %% own monitor, but async requests were dispatched fire-and-forget, so
+    %% push a worker_died error to each async reply_to before we exit --
+    %% otherwise those callers would block until their await/request timeout.
+    maps:foreach(fun notify_worker_died/2, Reqs),
+    %% port_close/1 raises badarg if the port is already dead (the common case
+    %% when we get here via port death); ignore it -- we're terminating anyway.
+    try port_close(Port)
+    catch error:badarg -> ok
+    end,
+    ok.
+
+notify_worker_died(From, {_Tref, {async, _, _} = Kind}) ->
+    deliver_error(Kind, From, #{code => worker_died, message => <<>>});
+notify_worker_died(_From, {_Tref, sync}) ->
     ok.
 
 -doc false.

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -37,7 +37,8 @@ by the `reply_to` option):
 {katipo_error, Ref, #{code := error_code(), message := error_msg()}}
 ```
 
-Use `await/1,2` to block until the response arrives.
+Use `await/1,2` to block until the response arrives, or `cancel/2` to abort an
+in-flight request (no response is then delivered).
 
 If the pool worker handling an in-flight async request dies (e.g. its port
 crashes), a `{katipo_error, Ref, #{code => worker_died}}` message is delivered
@@ -91,6 +92,7 @@ Note: async requests do not currently emit OTel spans or metrics.
 -export([async_delete/3]).
 -export([await/1]).
 -export([await/2]).
+-export([cancel/2]).
 
 -export([check_opts/1]).
 
@@ -771,6 +773,24 @@ await(Ref, Timeout) ->
         {error, #{code => await_timeout, message => <<>>}}
     end.
 
+-doc """
+Cancels the async request identified by `Ref` (returned by `async_get/2,3`,
+`async_req/2`, etc.).
+
+Best-effort: once the cancel takes effect no `{katipo_response, Ref, _}` or
+`{katipo_error, Ref, _}` message is delivered. A message that was already
+delivered before the cancel raced in may still be in the receiver's mailbox, so
+callers should be prepared to flush a late one. Cancelling an unknown or
+already-completed `Ref` is a harmless no-op.
+
+Note: the in-flight HTTP transfer is not aborted — it completes in the
+background and its result is discarded.
+""".
+-spec cancel(katipo_pool:name(), reference()) -> ok.
+cancel(PoolName, Ref) ->
+    wpool:broadcast(PoolName, {cancel, Ref}),
+    ok.
+
 -doc false.
 %% Build a validated, timeout-stamped #req{} from an opts map. Shared by the
 %% sync req/2 and async_req/2 entry points.
@@ -893,6 +913,10 @@ handle_cast({async_req, ReplyTo, UserRef, Req = #req{timeout = Timeout}},
     Tref = erlang:start_timer(Timeout, self(), {req_timeout, InternalFrom}),
     Reqs2 = Reqs#{InternalFrom => {Tref, {async, ReplyTo, UserRef}}},
     {noreply, State#state{reqs = Reqs2}};
+handle_cast({cancel, UserRef}, State = #state{port = Port, reqs = Reqs}) ->
+    %% Broadcast reaches every worker; only the one holding this request acts.
+    Reqs2 = cancel_async(Port, UserRef, Reqs),
+    {noreply, State#state{reqs = Reqs2}};
 handle_cast(Msg, State) ->
     logger:error("Unexpected cast: ~p", [Msg]),
     {noreply, State}.
@@ -974,6 +998,26 @@ notify_worker_died(From, {_Tref, {async, _, _} = Kind}) ->
     deliver_error(Kind, From, #{code => worker_died, message => <<>>});
 notify_worker_died(_From, {_Tref, sync}) ->
     ok.
+
+%% Cancel the async request with this user Ref, if this worker holds it: tell
+%% the port to abort the transfer, cancel the timer, and drop the reqs entry so
+%% no response is delivered.
+cancel_async(Port, UserRef, Reqs) ->
+    case find_async(UserRef, Reqs) of
+        {ok, {Self, Ref} = From, Tref} ->
+            _ = erlang:cancel_timer(Tref),
+            true = port_command(Port, term_to_binary({Self, Ref, cancel})),
+            maps:remove(From, Reqs);
+        error ->
+            Reqs
+    end.
+
+find_async(UserRef, Reqs) ->
+    case [{From, Tref}
+          || From := {Tref, {async, _ReplyTo, UR}} <- Reqs, UR =:= UserRef] of
+        [{From, Tref} | _] -> {ok, From, Tref};
+        [] -> error
+    end.
 
 -doc false.
 code_change(_OldVsn, State, _Extra) ->

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -55,6 +55,24 @@ All request functions return `t:response/0`:
 -export([delete/2]).
 -export([delete/3]).
 
+-export([async_req/2]).
+-export([async_get/2]).
+-export([async_get/3]).
+-export([async_post/2]).
+-export([async_post/3]).
+-export([async_put/2]).
+-export([async_put/3]).
+-export([async_head/2]).
+-export([async_head/3]).
+-export([async_options/2]).
+-export([async_options/3]).
+-export([async_patch/2]).
+-export([async_patch/3]).
+-export([async_delete/2]).
+-export([async_delete/3]).
+-export([await/1]).
+-export([await/2]).
+
 -export([check_opts/1]).
 
 %% only for mocking during tests
@@ -288,7 +306,8 @@ All request functions return `t:response/0`:
         ech_required |
         curl_last |
         %% returned by us, not curl
-        bad_opts.
+        bad_opts |
+        await_timeout.
 
 -type curlmopt() ::
         max_total_connections |
@@ -337,6 +356,7 @@ All request functions return `t:response/0`:
 %% See [https://curl.haxx.se/libcurl/c/CURLOPT_USERPWD.html]
 -type request() :: #{url := binary(),
                     method := method(),
+                    reply_to => pid(),
                     headers => headers(),
                     cookiejar => cookiejar(),
                     body => req_body(),
@@ -366,7 +386,8 @@ All request functions return `t:response/0`:
                     dns_cache_timeout => integer(),
                     ca_cache_timeout => integer(),
                     pipewait => boolean()}.
--type opts() :: #{headers => headers(),
+-type opts() :: #{reply_to => pid(),
+                    headers => headers(),
                     cookiejar => cookiejar(),
                     body => req_body(),
                     connecttimeout_ms => connecttimeout_ms(),
@@ -404,6 +425,9 @@ All request functions return `t:response/0`:
                            metrics => proplists:proplist()}} |
                     {error, #{code := error_code(),
                               message := error_msg()}}.
+-type async_response() :: {ok, reference()} |
+                          {error, #{code := error_code(),
+                                    message := error_msg()}}.
 -type http_auth() :: basic | digest | ntlm | negotiate.
 -type http_auth_int() :: ?CURLAUTH_UNDEFINED |
                          ?CURLAUTH_BASIC |
@@ -459,6 +483,7 @@ All request functions return `t:response/0`:
 -export_type([sslkey/0]).
 -export_type([sslkey_blob/0]).
 -export_type([userpwd/0]).
+-export_type([async_response/0]).
 
 -record(req, {
           method = ?GET :: method_int(),
@@ -590,6 +615,76 @@ delete(PoolName, Url) ->
 delete(PoolName, Url, Opts) ->
     req(PoolName, Opts#{url => Url, method => delete}).
 
+-doc #{equiv => async_get/3}.
+-spec async_get(katipo_pool:name(), url()) -> async_response().
+async_get(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => get}).
+
+-doc "Performs an async HTTP GET request. Returns `{ok, Ref}` immediately. The response is delivered as a `{katipo_response, Ref, Response}` message.".
+-spec async_get(katipo_pool:name(), url(), opts()) -> async_response().
+async_get(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => get}).
+
+-doc #{equiv => async_post/3}.
+-spec async_post(katipo_pool:name(), url()) -> async_response().
+async_post(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => post}).
+
+-doc "Performs an async HTTP POST request. Returns `{ok, Ref}` immediately.".
+-spec async_post(katipo_pool:name(), url(), opts()) -> async_response().
+async_post(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => post}).
+
+-doc #{equiv => async_put/3}.
+-spec async_put(katipo_pool:name(), url()) -> async_response().
+async_put(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => put}).
+
+-doc "Performs an async HTTP PUT request. Returns `{ok, Ref}` immediately.".
+-spec async_put(katipo_pool:name(), url(), opts()) -> async_response().
+async_put(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => put}).
+
+-doc #{equiv => async_head/3}.
+-spec async_head(katipo_pool:name(), url()) -> async_response().
+async_head(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => head}).
+
+-doc "Performs an async HTTP HEAD request. Returns `{ok, Ref}` immediately.".
+-spec async_head(katipo_pool:name(), url(), opts()) -> async_response().
+async_head(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => head}).
+
+-doc #{equiv => async_options/3}.
+-spec async_options(katipo_pool:name(), url()) -> async_response().
+async_options(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => options}).
+
+-doc "Performs an async HTTP OPTIONS request. Returns `{ok, Ref}` immediately.".
+-spec async_options(katipo_pool:name(), url(), opts()) -> async_response().
+async_options(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => options}).
+
+-doc #{equiv => async_patch/3}.
+-spec async_patch(katipo_pool:name(), url()) -> async_response().
+async_patch(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => patch}).
+
+-doc "Performs an async HTTP PATCH request. Returns `{ok, Ref}` immediately.".
+-spec async_patch(katipo_pool:name(), url(), opts()) -> async_response().
+async_patch(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => patch}).
+
+-doc #{equiv => async_delete/3}.
+-spec async_delete(katipo_pool:name(), url()) -> async_response().
+async_delete(PoolName, Url) ->
+    async_req(PoolName, #{url => Url, method => delete}).
+
+-doc "Performs an async HTTP DELETE request. Returns `{ok, Ref}` immediately.".
+-spec async_delete(katipo_pool:name(), url(), opts()) -> async_response().
+async_delete(PoolName, Url, Opts) ->
+    async_req(PoolName, Opts#{url => Url, method => delete}).
+
 -doc "Performs an HTTP request using the full request map.".
 -spec req(katipo_pool:name(), request()) -> response().
 req(PoolName, Opts)
@@ -601,6 +696,57 @@ req(PoolName, Opts)
             do_req_with_span(PoolName, Req);
         {error, _} = Error ->
             Error
+    end.
+
+-doc """
+Performs an async HTTP request using the full request map.
+
+Returns `{ok, Ref}` immediately. The response is delivered as a
+`{katipo_response, Ref, ResponseMap}` or `{katipo_error, Ref, ErrorMap}`
+message to the process specified by the `reply_to` option (defaults to `self()`).
+
+Use `await/1,2` to block until the response arrives.
+""".
+-spec async_req(katipo_pool:name(), request()) -> async_response().
+async_req(PoolName, Opts)
+  when is_map(Opts) ->
+    ReplyTo = maps:get(reply_to, Opts, self()),
+    Opts2 = maps:remove(reply_to, Opts),
+    case process_opts(Opts2) of
+        {ok, #req{url = undefined}} ->
+            {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
+        {ok, Req} ->
+            UserRef = make_ref(),
+            Timeout = ?MODULE:get_timeout(Req),
+            Req2 = Req#req{timeout = Timeout},
+            wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req2}, random_worker),
+            {ok, UserRef};
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc #{equiv => await/2}.
+-spec await(reference()) -> response().
+await(Ref) ->
+    await(Ref, ?DEFAULT_REQ_TIMEOUT).
+
+-doc "Blocks until an async response for `Ref` arrives or the timeout expires.".
+-spec await(reference(), timeout()) -> response().
+await(Ref, Timeout) ->
+    receive
+        {katipo_response, Ref, Response} ->
+            {ok, Response};
+        {katipo_error, Ref, Error} ->
+            {error, Error}
+    after Timeout ->
+        %% Flush any late-arriving response for this Ref
+        receive
+            {katipo_response, Ref, _} -> ok;
+            {katipo_error, Ref, _} -> ok
+        after 0 ->
+            ok
+        end,
+        {error, #{code => await_timeout, message => <<>>}}
     end.
 
 -doc false.
@@ -699,42 +845,120 @@ init([CurlOpts]) ->
     end.
 
 -doc false.
-handle_call(#req{method = Method,
-                 url = Url,
-                 headers = Headers,
-                 cookiejar = CookieJar,
-                 body = Body,
-                 connecttimeout_ms = ConnTimeoutMs,
-                 followlocation = FollowLocation,
-                 ssl_verifyhost = SslVerifyHost,
-                 ssl_verifypeer = SslVerifyPeer,
-                 capath = CAPath,
-                 cacert = CACert,
-                 timeout_ms = TimeoutMs,
-                 maxredirs = MaxRedirs,
-                 timeout = Timeout,
-                 http_auth = HTTPAuth,
-                 username = Username,
-                 password = Password,
-                 proxy = Proxy,
-                 tcp_fastopen = TCPFastOpen,
-                 interface = Interface,
-                 unix_socket_path = UnixSocketPath,
-                 doh_url = DOHURL,
-                 http_version = HTTPVersion,
-                 sslversion = SSLVersion,
-                 verbose = Verbose,
-                 sslcert = SSLCert,
-                 sslkey = SSLKey,
-                 sslkey_blob = SSLKeyBlob,
-                 keypasswd = KeyPasswd,
-                 userpwd = UserPwd,
-                 dns_cache_timeout = DNSCacheTimeout,
-                 ca_cache_timeout = CACacheTimeout,
-                 pipewait = Pipewait},
-             From,
-             State = #state{port = Port, reqs = Reqs}) ->
-    {Self, Ref} = From,
+handle_call(Req = #req{timeout = Timeout}, From, State = #state{port = Port, reqs = Reqs}) ->
+    send_to_port(Port, From, Req),
+    Tref = erlang:start_timer(Timeout, self(), {req_timeout, From}),
+    Reqs2 = Reqs#{From => Tref},
+    {noreply, State#state{reqs = Reqs2}}.
+
+-doc false.
+handle_cast({async_req, ReplyTo, UserRef, Req = #req{timeout = Timeout}},
+            State = #state{port = Port, reqs = Reqs}) ->
+    InternalFrom = {self(), make_ref()},
+    send_to_port(Port, InternalFrom, Req),
+    Tref = erlang:start_timer(Timeout, self(), {req_timeout, InternalFrom}),
+    Reqs2 = Reqs#{InternalFrom => {Tref, {async, ReplyTo, UserRef}}},
+    {noreply, State#state{reqs = Reqs2}};
+handle_cast(Msg, State) ->
+    logger:error("Unexpected cast: ~p", [Msg]),
+    {noreply, State}.
+
+-doc false.
+handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
+    {Result, {From, Response}} =
+        case binary_to_term(Data) of
+            {ok, {From0, {Status, Headers, CookieJar, Body, Metrics}}} ->
+                R = #{status => Status,
+                      headers => parse_headers(Headers),
+                      cookiejar => CookieJar,
+                      body => Body},
+                {ok, {From0, {R, Metrics}}};
+            {error, {From0, {Code, Message, Metrics}}} ->
+                Error = #{code => Code, message => Message},
+                {error, {From0, {Error, Metrics}}}
+        end,
+    case maps:find(From, Reqs) of
+        {ok, Tref} when is_reference(Tref) ->
+            %% Sync path
+            _ = erlang:cancel_timer(Tref),
+            _ = gen_server:reply(From, {Result, Response});
+        {ok, {Tref, {async, ReplyTo, UserRef}}} ->
+            %% Async path — flatten into separate ok/error messages
+            {ResponseMap, _Metrics} = Response,
+            _ = erlang:cancel_timer(Tref),
+            case Result of
+                ok    -> ReplyTo ! {katipo_response, UserRef, ResponseMap};
+                error -> ReplyTo ! {katipo_error, UserRef, ResponseMap}
+            end;
+        error ->
+            ok
+    end,
+    Reqs2 = maps:remove(From, Reqs),
+    {noreply, State#state{reqs = Reqs2}};
+handle_info({timeout, Tref, {req_timeout, From}}, State = #state{reqs = Reqs}) ->
+    Reqs2 =
+        case maps:find(From, Reqs) of
+            {ok, Tref} when is_reference(Tref) ->
+                %% Sync path
+                Error = #{code => operation_timedout, message => <<>>},
+                Metrics = [],
+                _ = gen_server:reply(From, {error, {Error, Metrics}}),
+                maps:remove(From, Reqs);
+            {ok, {Tref, {async, ReplyTo, UserRef}}} ->
+                %% Async path
+                Error = #{code => operation_timedout, message => <<>>},
+                ReplyTo ! {katipo_error, UserRef, Error},
+                maps:remove(From, Reqs);
+            error ->
+                Reqs
+        end,
+    {noreply, State#state{reqs = Reqs2}};
+handle_info({'EXIT', Port, Reason}, State = #state{port = Port}) ->
+    logger:error("Port ~p died with reason: ~p", [Port, Reason]),
+    {stop, port_died, State}.
+
+-doc false.
+terminate(_Reason, #state{port = Port}) ->
+    true = port_close(Port),
+    ok.
+
+-doc false.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+send_to_port(Port, {Self, Ref},
+             #req{method = Method,
+                  url = Url,
+                  headers = Headers,
+                  cookiejar = CookieJar,
+                  body = Body,
+                  connecttimeout_ms = ConnTimeoutMs,
+                  followlocation = FollowLocation,
+                  ssl_verifyhost = SslVerifyHost,
+                  ssl_verifypeer = SslVerifyPeer,
+                  capath = CAPath,
+                  cacert = CACert,
+                  timeout_ms = TimeoutMs,
+                  maxredirs = MaxRedirs,
+                  http_auth = HTTPAuth,
+                  username = Username,
+                  password = Password,
+                  proxy = Proxy,
+                  tcp_fastopen = TCPFastOpen,
+                  interface = Interface,
+                  unix_socket_path = UnixSocketPath,
+                  doh_url = DOHURL,
+                  http_version = HTTPVersion,
+                  sslversion = SSLVersion,
+                  verbose = Verbose,
+                  sslcert = SSLCert,
+                  sslkey = SSLKey,
+                  sslkey_blob = SSLKeyBlob,
+                  keypasswd = KeyPasswd,
+                  userpwd = UserPwd,
+                  dns_cache_timeout = DNSCacheTimeout,
+                  ca_cache_timeout = CACacheTimeout,
+                  pipewait = Pipewait}) ->
     Opts = [{?CONNECTTIMEOUT_MS, ConnTimeoutMs},
             {?FOLLOWLOCATION, FollowLocation},
             {?SSL_VERIFYHOST, SslVerifyHost},
@@ -763,63 +987,7 @@ handle_call(#req{method = Method,
             {?CA_CACHE_TIMEOUT, CACacheTimeout},
             {?PIPEWAIT, Pipewait}],
     Command = {Self, Ref, Method, Url, Headers, CookieJar, Body, Opts},
-    true = port_command(Port, term_to_binary(Command)),
-    Tref = erlang:start_timer(Timeout, self(), {req_timeout, From}),
-    Reqs2 = Reqs#{From => Tref},
-    {noreply, State#state{reqs = Reqs2}}.
-
--doc false.
-handle_cast(Msg, State) ->
-    logger:error("Unexpected cast: ~p", [Msg]),
-    {noreply, State}.
-
--doc false.
-handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
-    {Result, {From, Response}} =
-        case binary_to_term(Data) of
-            {ok, {From0, {Status, Headers, CookieJar, Body, Metrics}}} ->
-                R = #{status => Status,
-                      headers => parse_headers(Headers),
-                      cookiejar => CookieJar,
-                      body => Body},
-                {ok, {From0, {R, Metrics}}};
-            {error, {From0, {Code, Message, Metrics}}} ->
-                Error = #{code => Code, message => Message},
-                {error, {From0, {Error, Metrics}}}
-        end,
-    case maps:find(From, Reqs) of
-        {ok, Tref} ->
-            _ = erlang:cancel_timer(Tref),
-            _ = gen_server:reply(From, {Result, Response});
-        error ->
-            ok
-    end,
-    Reqs2 = maps:remove(From, Reqs),
-    {noreply, State#state{reqs = Reqs2}};
-handle_info({timeout, Tref, {req_timeout, From}}, State = #state{reqs = Reqs}) ->
-    Reqs2 =
-        case maps:find(From, Reqs) of
-            {ok, Tref} ->
-                Error = #{code => operation_timedout, message => <<>>},
-                Metrics = [],
-                _ = gen_server:reply(From, {error, {Error, Metrics}}),
-                maps:remove(From, Reqs);
-            error ->
-                Reqs
-        end,
-    {noreply, State#state{reqs = Reqs2}};
-handle_info({'EXIT', Port, Reason}, State = #state{port = Port}) ->
-    logger:error("Port ~p died with reason: ~p", [Port, Reason]),
-    {stop, port_died, State}.
-
--doc false.
-terminate(_Reason, #state{port = Port}) ->
-    true = port_close(Port),
-    ok.
-
--doc false.
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+    true = port_command(Port, term_to_binary(Command)).
 
 -spec headers_to_binary(headers()) -> [binary()].
 headers_to_binary(Headers) ->
@@ -1027,6 +1195,8 @@ opt(pipewait, true, {Req, Errors}) ->
     {Req#req{pipewait = ?PIPEWAIT_TRUE}, Errors};
 opt(pipewait, false, {Req, Errors}) ->
     {Req#req{pipewait = ?PIPEWAIT_FALSE}, Errors};
+opt(reply_to, Pid, {Req, Errors}) when is_pid(Pid) ->
+    {Req, Errors};
 opt(K, V, {Req, Errors}) ->
     {Req, [{K, V} | Errors]}.
 

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -19,12 +19,27 @@ See `t:opts/0` for all available options and `t:request/0` for the full request 
 
 ## Responses
 
-All request functions return `t:response/0`:
+Synchronous request functions return `t:response/0`:
 
 ```erlang
 {ok, #{status := pos_integer(), headers := headers(), cookiejar := cookiejar(), body := body()}}
 {error, #{code := error_code(), message := error_msg()}}
 ```
+
+## Async Requests
+
+Async functions (`async_get/2,3`, `async_req/2`, etc.) return `{ok, Ref}` immediately
+and deliver the response as a message to the calling process (or the pid specified
+by the `reply_to` option):
+
+```erlang
+{katipo_response, Ref, #{status := pos_integer(), headers := headers(), ...}}
+{katipo_error, Ref, #{code := error_code(), message := error_msg()}}
+```
+
+Use `await/1,2` to block until the response arrives.
+
+Note: async requests do not currently emit OTel spans or metrics.
 """.
 
 -behaviour(gen_server).
@@ -711,18 +726,23 @@ Use `await/1,2` to block until the response arrives.
 async_req(PoolName, Opts)
   when is_map(Opts) ->
     ReplyTo = maps:get(reply_to, Opts, self()),
-    Opts2 = maps:remove(reply_to, Opts),
-    case process_opts(Opts2) of
-        {ok, #req{url = undefined}} ->
-            {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
-        {ok, Req} ->
-            UserRef = make_ref(),
-            Timeout = ?MODULE:get_timeout(Req),
-            Req2 = Req#req{timeout = Timeout},
-            wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req2}, random_worker),
-            {ok, UserRef};
-        {error, _} = Error ->
-            Error
+    case is_pid(ReplyTo) of
+        false ->
+            {error, error_map(bad_opts, <<"[{reply_to,invalid}]">>)};
+        true ->
+            Opts2 = maps:remove(reply_to, Opts),
+            case process_opts(Opts2) of
+                {ok, #req{url = undefined}} ->
+                    {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
+                {ok, Req} ->
+                    UserRef = make_ref(),
+                    Timeout = ?MODULE:get_timeout(Req),
+                    Req2 = Req#req{timeout = Timeout},
+                    wpool:cast(PoolName, {async_req, ReplyTo, UserRef, Req2}, random_worker),
+                    {ok, UserRef};
+                {error, _} = Error ->
+                    Error
+            end
     end.
 
 -doc #{equiv => await/2}.

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -568,8 +568,9 @@ redirect_to(Config) ->
     {ok, #{status := 302}} = katipo:get(?POOL, httpbin_url(Config, <<"/redirect-to?url=https://google.com">>), Opts).
 
 connecttimeout_ms(_) ->
+    %% Use TEST-NET-1 (RFC 5737) — guaranteed non-routable, so connect always times out
     {error, #{code := operation_timedout}} =
-        katipo:get(?POOL, <<"http://google.com">>, #{connecttimeout_ms => 1}).
+        katipo:get(?POOL, <<"http://192.0.2.1">>, #{connecttimeout_ms => 1}).
 
 followlocation_true(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
@@ -1484,7 +1485,7 @@ async_error(_Config) ->
         katipo:async_get(?POOL, <<"https://localhost">>, #{bad_option => bad_value}).
 
 async_timeout(_Config) ->
-    {ok, Ref} = katipo:async_get(?POOL, <<"http://google.com">>,
+    {ok, Ref} = katipo:async_get(?POOL, <<"http://192.0.2.1">>,
                                  #{connecttimeout_ms => 1}),
     receive
         {katipo_error, Ref, #{code := operation_timedout}} -> ok
@@ -1500,7 +1501,7 @@ async_await(Config) ->
 
 async_await_timeout(_Config) ->
     %% Request itself times out — await collects the error
-    {ok, Ref} = katipo:async_get(?POOL, <<"http://google.com">>,
+    {ok, Ref} = katipo:async_get(?POOL, <<"http://192.0.2.1">>,
                                  #{connecttimeout_ms => 1}),
     {error, #{code := operation_timedout}} = katipo:await(Ref).
 
@@ -1513,7 +1514,7 @@ async_await_explicit_timeout(Config) ->
 
 async_await_own_timeout(_Config) ->
     %% await/2 timeout fires before the response arrives
-    {ok, Ref} = katipo:async_get(?POOL, <<"http://google.com">>,
+    {ok, Ref} = katipo:async_get(?POOL, <<"http://192.0.2.1">>,
                                  #{timeout_ms => 30000, connecttimeout_ms => 30000}),
     {error, #{code := await_timeout}} = katipo:await(Ref, 1).
 

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -1425,23 +1425,15 @@ async_get(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
     Url = httpbin_url(Config, <<"/get">>),
     {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
-    receive
-        {katipo_response, Ref, #{status := 200}} -> ok
-    after 10000 ->
-        ct:fail(timeout)
-    end.
+    {ok, #{status := 200}} = katipo:await(Ref).
 
 async_get_with_opts(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
     Url = httpbin_url(Config, <<"/get?a=1">>),
     {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
-    receive
-        {katipo_response, Ref, #{status := 200, body := Body}} ->
-            Json = jsx:decode(Body),
-            ?assertEqual(<<"1">>, maps:get(<<"a">>, maps:get(<<"args">>, Json)))
-    after 10000 ->
-        ct:fail(timeout)
-    end.
+    {ok, #{status := 200, body := Body}} = katipo:await(Ref),
+    Json = jsx:decode(Body),
+    ?assertEqual(<<"1">>, maps:get(<<"a">>, maps:get(<<"args">>, Json))).
 
 async_post(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
@@ -1449,23 +1441,15 @@ async_post(Config) ->
     {ok, Ref} = katipo:async_post(?POOL, Url,
                                   Opts#{headers => [{<<"Content-Type">>, <<"application/json">>}],
                                         body => <<"hello">>}),
-    receive
-        {katipo_response, Ref, #{status := 200, body := Body}} ->
-            Json = jsx:decode(Body),
-            ?assertEqual(<<"hello">>, maps:get(<<"data">>, Json))
-    after 10000 ->
-        ct:fail(timeout)
-    end.
+    {ok, #{status := 200, body := Body}} = katipo:await(Ref),
+    Json = jsx:decode(Body),
+    ?assertEqual(<<"hello">>, maps:get(<<"data">>, Json)).
 
 async_req(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
     Url = httpbin_url(Config, <<"/get">>),
     {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url, method => get}),
-    receive
-        {katipo_response, Ref, #{status := 200}} -> ok
-    after 10000 ->
-        ct:fail(timeout)
-    end.
+    {ok, #{status := 200}} = katipo:await(Ref).
 
 async_reply_to(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
@@ -1492,8 +1476,12 @@ async_error(_Config) ->
         katipo:async_get(?POOL, <<"https://localhost">>, #{bad_option => bad_value}).
 
 async_timeout(_Config) ->
+    %% Cap timeout_ms so katipo's own timeout deterministically delivers the
+    %% error in ~2s. Relying on curl's connecttimeout_ms=1 alone is flaky under
+    %% load; the 30s default backstop would race the suite timetrap. Manual
+    %% receive (not await/1) to exercise the raw async message path.
     {ok, Ref} = katipo:async_get(?POOL, <<"http://192.0.2.1">>,
-                                 #{connecttimeout_ms => 1}),
+                                 #{connecttimeout_ms => 1, timeout_ms => 2000}),
     receive
         {katipo_error, Ref, #{code := operation_timedout}} -> ok
     after 10000 ->
@@ -1507,9 +1495,11 @@ async_await(Config) ->
     {ok, #{status := 200}} = katipo:await(Ref).
 
 async_await_timeout(_Config) ->
-    %% Request itself times out — await collects the error
+    %% Request itself times out — await collects the error. Cap timeout_ms so
+    %% the timeout is delivered deterministically in ~2s rather than relying on
+    %% curl's flaky 1ms connecttimeout and racing the suite timetrap.
     {ok, Ref} = katipo:async_get(?POOL, <<"http://192.0.2.1">>,
-                                 #{connecttimeout_ms => 1}),
+                                 #{connecttimeout_ms => 1, timeout_ms => 2000}),
     {error, #{code := operation_timedout}} = katipo:await(Ref).
 
 async_await_explicit_timeout(Config) ->

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -250,6 +250,8 @@ groups() ->
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
+       otel_async_span_created,
+       otel_async_metrics_recorded,
        otel_url_sanitization,
        otel_noop_metrics_no_crash]},
      {http1, [parallel],
@@ -1283,42 +1285,67 @@ httpbin_url(Config, Path) ->
 %% OpenTelemetry integration tests
 
 otel_span_created(_Config) ->
-    Self = self(),
-    application:set_env(opentelemetry, processors,
-                        [{otel_simple_processor, #{exporter => {otel_exporter_pid, Self}}}]),
-    application:stop(opentelemetry),
-    {ok, _} = application:ensure_all_started(opentelemetry),
-
+    ok = setup_span_exporter(),
     {ok, #{status := 200}} =
         katipo:get(?POOL, <<"https://localhost:8443/get">>,
                    #{ssl_verifyhost => false, ssl_verifypeer => false}),
-    receive
-        {span, #span{name = SpanName}} ->
-            ?assertEqual(<<"HTTP GET">>, SpanName)
-    after 5000 ->
-        ct:fail("Timeout waiting for span")
-    end.
+    assert_span_name(<<"HTTP GET">>).
 
 otel_metrics_recorded(_Config) ->
-    Self = self(),
-    ReadersConfig = [#{module => otel_metric_reader,
-                       config => #{exporter => {otel_metric_exporter_pid, Self},
-                                  export_interval_ms => 100}}],
-    application:set_env(opentelemetry_experimental, readers, ReadersConfig),
-    application:stop(opentelemetry_experimental),
-    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
-
-    %% Re-register instruments with new meter provider
-    ok = katipo_metrics:init(),
-
+    ok = setup_metric_reader(),
     flush_otel_metrics(),
     {ok, #{status := 200}} =
         katipo:get(?POOL, <<"https://localhost:8443/get">>,
                    #{ssl_verifyhost => false, ssl_verifypeer => false}),
+    assert_request_counter().
 
+otel_async_span_created(_Config) ->
+    ok = setup_span_exporter(),
+    {ok, Ref} =
+        katipo:async_get(?POOL, <<"https://localhost:8443/get">>,
+                         #{ssl_verifyhost => false, ssl_verifypeer => false}),
+    {ok, #{status := 200}} = katipo:await(Ref),
+    assert_span_name(<<"HTTP GET">>).
+
+otel_async_metrics_recorded(_Config) ->
+    ok = setup_metric_reader(),
+    flush_otel_metrics(),
+    {ok, Ref} =
+        katipo:async_get(?POOL, <<"https://localhost:8443/get">>,
+                         #{ssl_verifyhost => false, ssl_verifypeer => false}),
+    {ok, #{status := 200}} = katipo:await(Ref),
+    assert_request_counter().
+
+%% Point the OTel span/metric exporters at this (the test) process so it can
+%% receive {span, _} / {otel_metric, _} messages.
+setup_span_exporter() ->
+    application:set_env(opentelemetry, processors,
+                        [{otel_simple_processor, #{exporter => {otel_exporter_pid, self()}}}]),
+    application:stop(opentelemetry),
+    {ok, _} = application:ensure_all_started(opentelemetry),
+    ok.
+
+setup_metric_reader() ->
+    ReadersConfig = [#{module => otel_metric_reader,
+                       config => #{exporter => {otel_metric_exporter_pid, self()},
+                                  export_interval_ms => 100}}],
+    application:set_env(opentelemetry_experimental, readers, ReadersConfig),
+    application:stop(opentelemetry_experimental),
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+    %% Re-register instruments with the new meter provider
+    ok = katipo_metrics:init().
+
+assert_span_name(Expected) ->
+    receive
+        {span, #span{name = SpanName}} ->
+            ?assertEqual(Expected, SpanName)
+    after 5000 ->
+        ct:fail("Timeout waiting for span")
+    end.
+
+assert_request_counter() ->
     ok = otel_meter_server:force_flush(),
     timer:sleep(300),
-
     Metrics = collect_otel_metrics(),
     ?assert(length(Metrics) > 0),
     HasRequestCounter = lists:any(

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -235,7 +235,14 @@ groups() ->
        async_await_timeout,
        async_await_explicit_timeout,
        async_await_own_timeout,
-       async_multiple_outstanding]},
+       async_multiple_outstanding,
+       async_put,
+       async_head,
+       async_options,
+       async_patch,
+       async_delete,
+       async_invalid_reply_to,
+       async_url_missing]},
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
@@ -1533,3 +1540,41 @@ async_multiple_outstanding(Config) ->
         Expected = integer_to_binary(N),
         ?assertEqual(Expected, maps:get(<<"n">>, maps:get(<<"args">>, Json)))
     end, Results).
+
+async_put(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/put">>),
+    {ok, Ref} = katipo:async_put(?POOL, Url, Opts#{body => <<"data">>}),
+    {ok, #{status := 200}} = katipo:await(Ref).
+
+async_head(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_head(?POOL, Url, Opts),
+    {ok, #{status := 200}} = katipo:await(Ref).
+
+async_options(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_options(?POOL, Url, Opts),
+    {ok, #{status := 200}} = katipo:await(Ref).
+
+async_patch(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/patch">>),
+    {ok, Ref} = katipo:async_patch(?POOL, Url, Opts#{body => <<"data">>}),
+    {ok, #{status := 200}} = katipo:await(Ref).
+
+async_delete(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/delete">>),
+    {ok, Ref} = katipo:async_delete(?POOL, Url, Opts),
+    {ok, #{status := 200}} = katipo:await(Ref).
+
+async_invalid_reply_to(_Config) ->
+    {error, #{code := bad_opts, message := <<"[{reply_to,invalid}]">>}} =
+        katipo:async_get(?POOL, <<"https://localhost">>, #{reply_to => not_a_pid}).
+
+async_url_missing(_Config) ->
+    {error, #{code := bad_opts}} =
+        katipo:async_req(?POOL, #{method => get}).

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -92,6 +92,10 @@ init_per_group(digest, Config) ->
      {req_opts, #{http_version => curl_http_version_1_1,
                   ssl_verifyhost => false,
                   ssl_verifypeer => false}}] ++ Config;
+init_per_group(async, Config) ->
+    [{httpbin_base, <<"https://localhost:8443">>},
+     {req_opts, #{ssl_verifyhost => false,
+                  ssl_verifypeer => false}}] ++ Config;
 init_per_group(_, Config) ->
     Config.
 
@@ -219,6 +223,19 @@ groups() ->
       [badssl_client_cert]},
      {port, [],
       [max_total_connections]},
+     {async, [parallel],
+      [async_get,
+       async_get_with_opts,
+       async_post,
+       async_req,
+       async_reply_to,
+       async_error,
+       async_timeout,
+       async_await,
+       async_await_timeout,
+       async_await_explicit_timeout,
+       async_await_own_timeout,
+       async_multiple_outstanding]},
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
@@ -242,6 +259,7 @@ all() ->
                   {group, pool},
                   {group, https_mutual},
                   {group, port},
+                  {group, async},
                   {group, otel}],
     %% HTTP/2 tests always run (local httpbin supports HTTP/2)
     Http2Groups = [{group, http2}],
@@ -1392,3 +1410,125 @@ otel_url_sanitization(_Config) ->
     ?assertEqual(<<"example.com">>, Host6),
 
     ok.
+
+%% Async API tests
+
+async_get(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
+    receive
+        {katipo_response, Ref, #{status := 200}} -> ok
+    after 10000 ->
+        ct:fail(timeout)
+    end.
+
+async_get_with_opts(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get?a=1">>),
+    {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
+    receive
+        {katipo_response, Ref, #{status := 200, body := Body}} ->
+            Json = jsx:decode(Body),
+            ?assertEqual(<<"1">>, maps:get(<<"a">>, maps:get(<<"args">>, Json)))
+    after 10000 ->
+        ct:fail(timeout)
+    end.
+
+async_post(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/post">>),
+    {ok, Ref} = katipo:async_post(?POOL, Url,
+                                  Opts#{headers => [{<<"Content-Type">>, <<"application/json">>}],
+                                        body => <<"hello">>}),
+    receive
+        {katipo_response, Ref, #{status := 200, body := Body}} ->
+            Json = jsx:decode(Body),
+            ?assertEqual(<<"hello">>, maps:get(<<"data">>, Json))
+    after 10000 ->
+        ct:fail(timeout)
+    end.
+
+async_req(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url, method => get}),
+    receive
+        {katipo_response, Ref, #{status := 200}} -> ok
+    after 10000 ->
+        ct:fail(timeout)
+    end.
+
+async_reply_to(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    Self = self(),
+    Pid = spawn_link(fun() ->
+        receive
+            {katipo_response, _Ref, #{status := 200}} ->
+                Self ! async_reply_to_ok
+        after 10000 ->
+            Self ! async_reply_to_fail
+        end
+    end),
+    {ok, _Ref} = katipo:async_get(?POOL, Url, Opts#{reply_to => Pid}),
+    receive
+        async_reply_to_ok -> ok;
+        async_reply_to_fail -> ct:fail(reply_to_timeout)
+    after 15000 ->
+        ct:fail(timeout)
+    end.
+
+async_error(_Config) ->
+    {error, #{code := bad_opts}} =
+        katipo:async_get(?POOL, <<"https://localhost">>, #{bad_option => bad_value}).
+
+async_timeout(_Config) ->
+    {ok, Ref} = katipo:async_get(?POOL, <<"http://google.com">>,
+                                 #{connecttimeout_ms => 1}),
+    receive
+        {katipo_error, Ref, #{code := operation_timedout}} -> ok
+    after 10000 ->
+        ct:fail(timeout)
+    end.
+
+async_await(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
+    {ok, #{status := 200}} = katipo:await(Ref).
+
+async_await_timeout(_Config) ->
+    %% Request itself times out — await collects the error
+    {ok, Ref} = katipo:async_get(?POOL, <<"http://google.com">>,
+                                 #{connecttimeout_ms => 1}),
+    {error, #{code := operation_timedout}} = katipo:await(Ref).
+
+async_await_explicit_timeout(Config) ->
+    %% await/2 with an explicit timeout that is long enough
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
+    {ok, #{status := 200}} = katipo:await(Ref, 10000).
+
+async_await_own_timeout(_Config) ->
+    %% await/2 timeout fires before the response arrives
+    {ok, Ref} = katipo:async_get(?POOL, <<"http://google.com">>,
+                                 #{timeout_ms => 30000, connecttimeout_ms => 30000}),
+    {error, #{code := await_timeout}} = katipo:await(Ref, 1).
+
+async_multiple_outstanding(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Urls = [httpbin_url(Config, <<"/get?n=", (integer_to_binary(N))/binary>>)
+            || N <- lists:seq(1, 5)],
+    Refs = [{N, begin
+                    {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
+                    Ref
+                end}
+            || {N, Url} <- lists:zip(lists:seq(1, 5), Urls)],
+    Results = [{N, katipo:await(Ref)} || {N, Ref} <- Refs],
+    lists:foreach(fun({N, {ok, #{status := 200, body := Body}}}) ->
+        Json = jsx:decode(Body),
+        Expected = integer_to_binary(N),
+        ?assertEqual(Expected, maps:get(<<"n">>, maps:get(<<"args">>, Json)))
+    end, Results).

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -242,7 +242,9 @@ groups() ->
        async_patch,
        async_delete,
        async_invalid_reply_to,
-       async_url_missing]},
+       async_url_missing,
+       async_worker_death,
+       async_worker_death_reply_to]},
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
@@ -1026,15 +1028,11 @@ port_garbage_input(Config) ->
     PoolName = port_garbage_test,
     PoolSize = 1,
     {ok, _} = katipo_pool:start(PoolName, PoolSize),
-    WorkerName = wpool_pool:best_worker(PoolName),
-    WorkerPid = whereis(WorkerName),
-    {state, _, _, {state, Port, _}, _} = sys:get_state(WorkerPid),
+    {Port, _} = worker_state(PoolName),
     true = port_command(Port, <<"hdfjkshkjsdfgjsgafdjgsdjgfj">>),
     Fun = fun() ->
-                  WorkerName2 = wpool_pool:best_worker(PoolName),
-                  WorkerPid2 = whereis(WorkerName2),
-                  case sys:get_state(WorkerPid2) of
-                      {state, _, _, {state, Port2, _}, _} when Port =/= Port2 ->
+                  case worker_state(PoolName) of
+                      {Port2, _} when Port =/= Port2 ->
                           {ok, #{status := 200}} =
                               katipo:get(PoolName, Url, BaseOpts),
                           true
@@ -1050,16 +1048,10 @@ port_death(Config) ->
     PoolName = port_death_test,
     PoolSize = 1,
     {ok, _} = katipo_pool:start(PoolName, PoolSize),
-    WorkerName = wpool_pool:best_worker(PoolName),
-    WorkerPid = whereis(WorkerName),
-    {state, _, _, {state, Port, _}, _} = sys:get_state(WorkerPid),
-    {os_pid, OsPid} = erlang:port_info(Port, os_pid),
-    os:cmd("kill -9 " ++ integer_to_list(OsPid)),
+    Port = kill_worker_port(PoolName),
     Fun = fun() ->
-                  WorkerName2 = wpool_pool:best_worker(PoolName),
-                  WorkerPid2 = whereis(WorkerName2),
-                  case sys:get_state(WorkerPid2) of
-                      {state, _, _, {state, Port2, _}, _} when Port =/= Port2 ->
+                  case worker_state(PoolName) of
+                      {Port2, _} when Port =/= Port2 ->
                           {ok, #{status := 200}} =
                               katipo:get(PoolName, Url, BaseOpts),
                           true
@@ -1568,3 +1560,72 @@ async_invalid_reply_to(_Config) ->
 async_url_missing(_Config) ->
     {error, #{code := bad_opts}} =
         katipo:async_req(?POOL, #{method => get}).
+
+async_worker_death(Config) ->
+    %% A worker dying (port killed) while an async request is in flight must
+    %% deliver worker_died promptly, not leave the caller blocked until its
+    %% await/request timeout.
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    PoolName = async_worker_death_test,
+    {ok, _} = katipo_pool:start(PoolName, 1),
+    %% /delay keeps the request in flight so it's still registered on the
+    %% worker when we kill the port.
+    Url = httpbin_url(Config, <<"/delay/5">>),
+    {ok, Ref} = katipo:async_get(PoolName, Url, Opts),
+    ok = wait_for_inflight(PoolName),
+    _ = kill_worker_port(PoolName),
+    %% Prompt worker_died (well under /delay/5 and the 30s default) proves
+    %% terminate/2 pushed the error rather than us hitting a timeout.
+    {error, #{code := worker_died}} = katipo:await(Ref, 5000),
+    ok = katipo_pool:stop(PoolName).
+
+async_worker_death_reply_to(Config) ->
+    %% The death notification must reach a third-party reply_to, not just an
+    %% awaiter -- a plain message consumer gets worker_died pushed to it.
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    PoolName = async_worker_death_reply_to_test,
+    {ok, _} = katipo_pool:start(PoolName, 1),
+    Self = self(),
+    Collector = spawn_link(fun() ->
+        receive
+            {katipo_error, _Ref, #{code := worker_died}} ->
+                Self ! worker_died_seen
+        after 5000 ->
+            Self ! worker_died_missing
+        end
+    end),
+    Url = httpbin_url(Config, <<"/delay/5">>),
+    {ok, _Ref} = katipo:async_get(PoolName, Url, Opts#{reply_to => Collector}),
+    ok = wait_for_inflight(PoolName),
+    _ = kill_worker_port(PoolName),
+    receive
+        worker_died_seen -> ok;
+        worker_died_missing -> ct:fail(no_worker_died_message)
+    after 10000 ->
+        ct:fail(timeout)
+    end,
+    ok = katipo_pool:stop(PoolName).
+
+%% Block until the (size-1) pool's worker has a request registered, so a
+%% subsequent port kill happens with the request genuinely in flight.
+wait_for_inflight(PoolName) ->
+    Fun = fun() ->
+                  {_Port, Reqs} = worker_state(PoolName),
+                  map_size(Reqs) > 0
+          end,
+    true = repeat_until_true(Fun),
+    ok.
+
+%% Kill the (size-1) pool's worker OS process and return the killed Port.
+kill_worker_port(PoolName) ->
+    {Port, _Reqs} = worker_state(PoolName),
+    {os_pid, OsPid} = erlang:port_info(Port, os_pid),
+    _ = os:cmd("kill -9 " ++ integer_to_list(OsPid)),
+    Port.
+
+%% Reach into a size-1 pool's single worker and return its {Port, Reqs}. The
+%% outer tuple is wpool_process's state wrapping katipo's #state{port, reqs}.
+worker_state(PoolName) ->
+    WorkerPid = whereis(wpool_pool:best_worker(PoolName)),
+    {state, _, _, {state, Port, Reqs}, _} = sys:get_state(WorkerPid),
+    {Port, Reqs}.

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -244,7 +244,9 @@ groups() ->
        async_invalid_reply_to,
        async_url_missing,
        async_worker_death,
-       async_worker_death_reply_to]},
+       async_worker_death_reply_to,
+       async_cancel,
+       async_cancel_after_complete]},
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
@@ -1606,12 +1608,51 @@ async_worker_death_reply_to(Config) ->
     end,
     ok = katipo_pool:stop(PoolName).
 
+async_cancel(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    PoolName = async_cancel_test,
+    {ok, _} = katipo_pool:start(PoolName, 1),
+    %% A slow request so it's genuinely in flight when we cancel it.
+    Url = httpbin_url(Config, <<"/delay/3">>),
+    {ok, Ref} = katipo:async_get(PoolName, Url, Opts),
+    ok = wait_for_inflight(PoolName),
+    ok = katipo:cancel(PoolName, Ref),
+    %% The worker drops the request (and tells the port to abort the transfer).
+    ok = wait_for_no_inflight(PoolName),
+    %% No response or error is delivered for a cancelled request, even past the
+    %% original /delay/3 completion time.
+    receive
+        {katipo_response, Ref, _} -> ct:fail(got_response_after_cancel);
+        {katipo_error, Ref, _} -> ct:fail(got_error_after_cancel)
+    after 5000 ->
+        ok
+    end,
+    %% The port/worker is still healthy after a cancel.
+    {ok, #{status := 200}} =
+        katipo:get(PoolName, httpbin_url(Config, <<"/get">>), Opts),
+    ok = katipo_pool:stop(PoolName).
+
+async_cancel_after_complete(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/get">>),
+    {ok, Ref} = katipo:async_get(?POOL, Url, Opts),
+    {ok, #{status := 200}} = katipo:await(Ref),
+    %% Cancelling an already-completed request is a harmless no-op.
+    ok = katipo:cancel(?POOL, Ref).
+
 %% Block until the (size-1) pool's worker has a request registered, so a
 %% subsequent port kill happens with the request genuinely in flight.
 wait_for_inflight(PoolName) ->
+    wait_for_reqs(PoolName, fun(N) -> N > 0 end).
+
+%% Poll until the (size-1) pool's worker has no requests registered.
+wait_for_no_inflight(PoolName) ->
+    wait_for_reqs(PoolName, fun(N) -> N =:= 0 end).
+
+wait_for_reqs(PoolName, Pred) ->
     Fun = fun() ->
                   {_Port, Reqs} = worker_state(PoolName),
-                  map_size(Reqs) > 0
+                  Pred(map_size(Reqs))
           end,
     true = repeat_until_true(Fun),
     ok.


### PR DESCRIPTION
Closes #115

Adds `async_get/2,3`, `async_post/2,3`, etc. and `async_req/2` that return `{ok, Ref}` immediately instead of blocking. Responses arrive as flat messages: `{katipo_response, Ref, ResponseMap}` for success, `{katipo_error, Ref, ErrorMap}` for errors.

Includes `await/1,2` helper for the common "fire N requests, collect results" pattern. Supports `reply_to` option to direct responses to a different process.

No C port changes — purely Erlang-side, using `wpool:cast` with synthetic internal refs for port correlation. API follows the pattern from the issue discussion (single complete response, not streaming chunks). Inspired by buoy's approach.

`await/2` distinguishes its own timeout (`await_timeout`) from request-level timeouts (`operation_timedout`), and flushes any late-arriving response from the mailbox on timeout.