### PR TITLE
fix: abort the port-side transfer when the request timer fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project are documented here. This project follows
   versions within the published ranges: `worker_pool` 6.5.3 and
   `opentelemetry_api` 1.5.0 (previously locked to 6.0.1 and 1.4.0).
 
+### Fixed
+- When the Erlang-side request timer fires (the backstop behind curl's own
+  timeouts), the worker now aborts the still-running transfer in the C port
+  instead of letting it hold a connection and a curl-multi slot until curl
+  notices on its own.
+
 ## [2.0.0-rc.2] — 2026-07-18
 
 ### Changed

--- a/formal/KatipoFixed.tla
+++ b/formal/KatipoFixed.tla
@@ -120,10 +120,14 @@ WorkerRecvReq(r) ==
           /\ UNCHANGED <<timerFired, sent, cancelled, effCancel,
                          effCancelSnap, deaths, cancelPollution>>
 
+\* abort_transfer/2: best-effort port_command of the cancel tuple with
+\* badarg swallowed -- nothing to write if the port is dead. Shared by the
+\* cancel and timeout paths, mirroring the code's shared helper.
+AbortPQ(r) == IF pAlive THEN Append(pQ, CancelMsg(r)) ELSE pQ
+
 \* handle_cast({cancel, Ref}) -> cancel_async (FIXED): cancel_timer, then
-\* maps:remove, then a best-effort port_command with badarg swallowed. The
-\* worker survives a cancel against a dead port and the request is out of
-\* Reqs either way.
+\* maps:remove, then abort_transfer. The worker survives a cancel against a
+\* dead port and the request is out of Reqs either way.
 WorkerRecvCancel(r) ==
   /\ wAlive /\ wQ # <<>> /\ Head(wQ) = CancelMsg(r)
   /\ wQ' = Tail(wQ)
@@ -131,7 +135,7 @@ WorkerRecvCancel(r) ==
      THEN /\ reqs' = reqs \ {r}
           /\ effCancel' = effCancel \cup {r}
           /\ effCancelSnap' = [effCancelSnap EXCEPT ![r] = delivered[r]]
-          /\ pQ' = IF pAlive THEN Append(pQ, CancelMsg(r)) ELSE pQ
+          /\ pQ' = AbortPQ(r)
      ELSE /\ UNCHANGED <<reqs, effCancel, effCancelSnap, pQ>>
   /\ UNCHANGED <<wAlive, pAlive, timerFired, conns, sent, cancelled,
                  delivered, deaths, cancelPollution>>
@@ -147,15 +151,17 @@ WorkerRecvResp(r) ==
   /\ UNCHANGED <<wAlive, pAlive, pQ, timerFired, conns, sent, cancelled,
                  effCancel, effCancelSnap, deaths, cancelPollution>>
 
-\* handle_info({timeout, Tref, {req_timeout, From}}): deliver iff in Reqs.
+\* handle_info({timeout, Tref, {req_timeout, From}}): deliver iff in Reqs,
+\* and abort_transfer the still-running transfer in the port.
 WorkerRecvTimeout(r) ==
   /\ wAlive /\ wQ # <<>> /\ Head(wQ) = TimeoutMsg(r)
   /\ wQ' = Tail(wQ)
   /\ IF r \in reqs
      THEN /\ delivered' = [delivered EXCEPT ![r] = @ + 1]
           /\ reqs' = reqs \ {r}
-     ELSE UNCHANGED <<delivered, reqs>>
-  /\ UNCHANGED <<wAlive, pAlive, pQ, timerFired, conns, sent, cancelled,
+          /\ pQ' = AbortPQ(r)
+     ELSE UNCHANGED <<delivered, reqs, pQ>>
+  /\ UNCHANGED <<wAlive, pAlive, timerFired, conns, sent, cancelled,
                  effCancel, effCancelSnap, deaths, cancelPollution>>
 
 \* handle_info({'EXIT', Port, _}) -> {stop, port_died} -> terminate/2.

--- a/src/katipo_worker.erl
+++ b/src/katipo_worker.erl
@@ -119,11 +119,16 @@ handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
     end,
     Reqs2 = maps:remove(From, Reqs),
     {noreply, State#state{reqs = Reqs2}};
-handle_info({timeout, Tref, {req_timeout, From}}, State = #state{reqs = Reqs}) ->
+handle_info({timeout, Tref, {req_timeout, From}},
+            State = #state{port = Port, reqs = Reqs}) ->
     Reqs2 =
         case maps:find(From, Reqs) of
             {ok, {Tref, Kind}} ->
                 _ = deliver_timeout(Kind, From),
+                %% Abort the transfer still running in the C port: its
+                %% eventual output would be dropped anyway now that the
+                %% request is out of Reqs.
+                abort_transfer(Port, From),
                 maps:remove(From, Reqs);
             _ ->
                 Reqs
@@ -158,22 +163,26 @@ notify_worker_died(_From, {_Tref, sync}) ->
 %% no response is delivered.
 cancel_async(Port, UserRef, Reqs) ->
     case find_async(UserRef, Reqs) of
-        {ok, {Self, Ref} = From, Tref, Obs} ->
+        {ok, From, Tref, Obs} ->
             _ = erlang:cancel_timer(Tref),
             Reqs2 = maps:remove(From, Reqs),
-            %% port_command raises badarg if the port died and its 'EXIT'
-            %% message is still queued behind this cancel. The transfer is
-            %% gone either way, so the abort is best-effort -- crashing here
-            %% would leave the request in Reqs and make terminate/2 send
-            %% worker_died to a caller who cancelled.
-            try port_command(Port, term_to_binary({Self, Ref, cancel}))
-            catch error:badarg -> ok
-            end,
+            abort_transfer(Port, From),
             katipo_span:end_async(Obs),
             Reqs2;
         error ->
             Reqs
     end.
+
+%% Ask the C port to abort the in-flight transfer identified by {Pid, Ref}
+%% (a no-op there if it already completed). Best-effort: port_command raises
+%% badarg if the port died and its 'EXIT' message is still queued behind us;
+%% the transfer is gone either way, and crashing here would let terminate/2
+%% message callers that have already been dealt with.
+abort_transfer(Port, {Pid, Ref}) ->
+    try port_command(Port, term_to_binary({Pid, Ref, cancel}))
+    catch error:badarg -> ok
+    end,
+    ok.
 
 find_async(UserRef, Reqs) ->
     case [{From, Tref, Obs}

--- a/test/katipo_async_failure_SUITE.erl
+++ b/test/katipo_async_failure_SUITE.erl
@@ -26,6 +26,7 @@
 -export([admission_error_when_port_closes_before_dispatch/1]).
 -export([admission_error_when_worker_restarting/1]).
 -export([no_message_after_cancel_against_dead_port/1]).
+-export([timeout_aborts_transfer_in_port/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -33,7 +34,8 @@
 all() ->
     [admission_error_when_port_closes_before_dispatch,
      admission_error_when_worker_restarting,
-     no_message_after_cancel_against_dead_port].
+     no_message_after_cancel_against_dead_port,
+     timeout_aborts_transfer_in_port].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(katipo),
@@ -151,6 +153,49 @@ no_message_after_cancel_against_dead_port(Config) ->
             ok
     end.
 
+%% When the Erlang-side request timer (the backstop behind curl's own
+%% timeouts) fires, the worker must deliver operation_timedout AND abort the
+%% transfer in the C port -- otherwise the transfer keeps holding a
+%% connection and a multi slot until curl notices. Verified at the protocol
+%% level: swap the worker's port for a loopback (cat) owned by this process,
+%% fire the request timer, and observe the {Pid, Ref, cancel} tuple the
+%% worker writes.
+timeout_aborts_transfer_in_port(Config) ->
+    Pool = ?config(pool, Config),
+    [WorkerName] = wpool:get_workers(Pool),
+    WorkerPid = whereis(WorkerName),
+
+    %% Long curl-side timeouts: the C port stays silent for the whole test,
+    %% so the only timeout that can fire is the one we send by hand.
+    {ok, Ref} = katipo:async_req(Pool, blackhole_req()),
+    RealPort = worker_port(WorkerPid),
+    [{From, {Tref, _Kind}}] = maps:to_list(worker_reqs(WorkerPid)),
+
+    FakePort = open_port({spawn, "/bin/cat"}, [{packet, 4}, binary]),
+    ok = swap_port(WorkerPid, FakePort),
+
+    %% Fire the request timer: this is exactly the message
+    %% erlang:start_timer/3 would deliver.
+    WorkerPid ! {timeout, Tref, {req_timeout, From}},
+
+    receive
+        {katipo_error, Ref, Error} ->
+            ?assertMatch(#{code := operation_timedout}, Error)
+    after 2000 ->
+            ct:fail(timeout_not_delivered)
+    end,
+    {Pid, InternalRef} = From,
+    receive
+        {FakePort, {data, Bin}} ->
+            ?assertEqual({Pid, InternalRef, cancel}, binary_to_term(Bin))
+    after 1000 ->
+            ct:fail(no_abort_written_to_port)
+    end,
+
+    %% Put the real port back so pool teardown closes it normally.
+    ok = swap_port(WorkerPid, RealPort),
+    true = port_close(FakePort).
+
 wait_until(_Fun, 0) ->
     {error, condition_never_true};
 wait_until(Fun, Retries) ->
@@ -168,3 +213,20 @@ worker_port(WorkerPid) ->
     [Port] = [P || P <- erlang:ports(),
                    erlang:port_info(P, connected) =:= {connected, WorkerPid}],
     Port.
+
+%% White-box helpers for the protocol test: a request's internal {Pid, Ref}
+%% identity and timer, and the port slot itself, have no public seam, so
+%% match katipo_worker's #state{port, reqs} at its known position inside
+%% wpool_process's wrapper (same idiom as katipo_SUITE's worker_state/1;
+%% fails loudly if the wrapper shape changes).
+worker_reqs(WorkerPid) ->
+    {state, _, _, {state, _Port, Reqs}, _} = sys:get_state(WorkerPid),
+    Reqs.
+
+swap_port(WorkerPid, NewPort) ->
+    _ = sys:replace_state(
+          WorkerPid,
+          fun(S = {state, _, _, {state, _, Reqs}, _}) ->
+                  setelement(4, S, {state, NewPort, Reqs})
+          end, 1000),
+    ok.


### PR DESCRIPTION
The Erlang-side request timer is a backstop behind curl's own timeouts: it fires at max(connecttimeout_ms, timeout_ms) and only wins when the transfer is still live in the C port — queue and pipe latency, curl timer starvation, or a wedged port. Until now, when the backstop fired the worker delivered operation_timedout and simply forgot the request, leaving the transfer running in the C port where it kept holding a connection and a curl-multi slot until curl noticed on its own; its eventual output was silently dropped.

The timeout path now aborts the transfer at delivery time by reusing the cancel machinery end to end: it writes the same {Pid, Ref, cancel} tuple the async cancel path uses, and the C side's existing cancel_conn frees the transfer (a no-op if it already completed). The port write is factored into a shared abort_transfer/2 used by both the cancel and timeout paths, carrying the best-effort badarg handling for a port that died with its EXIT still queued behind the message.

Verification runs at two levels. A new protocol-level test in katipo_async_failure_SUITE swaps the worker's port for a loopback owned by the test process, fires the exact timer message, and asserts both the operation_timedout delivery and the abort tuple written to the port — deterministic, no timing races, no httpbin needed. And the TLA+ model (formal/KatipoFixed.tla) now emits the port cancel from its timeout action via a shared AbortPQ operator mirroring the code's helper; TLC re-verifies all four properties (at-most-once delivery, nothing after an effective cancel, no cancel-caused delivery, eventual outcome) over 67k states.

Full Common Test suite (183 tests), dialyzer, xref, and lint pass. The change was run through a multi-agent simplify review, which tightened the test's white-box surface to a direct pattern match on the wpool wrapper and deduplicated the model's abort fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf2gxZLpxT4HvBfZKCgP3g
