### PR TITLE
build: refresh locked deps to worker_pool 6.5.3, opentelemetry_api 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+- Development and CI now build and test against the current dependency
+  versions within the published ranges: `worker_pool` 6.5.3 and
+  `opentelemetry_api` 1.5.0 (previously locked to 6.0.1 and 1.4.0).
+
 ## [2.0.0-rc.2] — 2026-07-18
 
 ### Changed

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,16 +1,16 @@
 {"1.2.0",
-[{<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.4.0">>},0},
+[{<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.5.0">>},0},
  {<<"opentelemetry_api_experimental">>,
   {pkg,<<"opentelemetry_api_experimental">>,<<"0.5.1">>},
   0},
- {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"6.0.1">>},0}]}.
+ {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"6.5.3">>},0}]}.
 [
 {pkg_hash,[
- {<<"opentelemetry_api">>, <<"63CA1742F92F00059298F478048DFB826F4B20D49534493D6919A0DB39B6DB04">>},
+ {<<"opentelemetry_api">>, <<"1A676F3E3340CAB81C763E939A42E11A70C22863F645AA06AAFEFC689B5550CF">>},
  {<<"opentelemetry_api_experimental">>, <<"1B5AFACFCBD0834390336C845BC8AE08C8CF0D69BBED72EE53D178798B93E074">>},
- {<<"worker_pool">>, <<"CA262C2DFB3B4AF661B206C82065D86F83922B7227508AA6E0BC34D3E5AE5135">>}]},
+ {<<"worker_pool">>, <<"C73849E313896FF6329B15DBAA0C432439BB22E0AC5228CF898915925ECEDBB8">>}]},
 {pkg_hash_ext,[
- {<<"opentelemetry_api">>, <<"3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58">>},
+ {<<"opentelemetry_api">>, <<"F53EC8A1337AE4A487D43AC89DA4BD3A3C99DDF576655D071DEED8B56A2D5DDA">>},
  {<<"opentelemetry_api_experimental">>, <<"10297057EADA47267D4F832011BECEF07D25690E6BF91FEBCCFC4E740DBA1A6F">>},
- {<<"worker_pool">>, <<"772E12CCB26909EA7F804B52E86E733DF66BB8150F683B591B0A762196494C74">>}]}
+ {<<"worker_pool">>, <<"BE6D63225C4BB538FBDDBAC38947C5DEF51B14FBF90B13CD9CF0C3349484FB73">>}]}
 ].


### PR DESCRIPTION
The published dependency requirements became semver ranges in 2.0.0-rc.2, but the lock — what CI and local builds actually test against — still pinned the old versions. This bumps the lock to the current versions within those ranges: worker_pool 6.0.1 → 6.5.3 and opentelemetry_api 1.4.0 → 1.5.0 (opentelemetry_api_experimental was already current at 0.5.1). Consumers are unaffected; this only keeps the tested-versions story honest.

The worker_pool jump is the one that matters — five minor versions of the library that wraps every katipo worker — and its surface is well covered: all requests (sync and async, via the admission call) funnel through wpool:call so every request test exercises the new call wrapper; the cancel tests cover broadcast; pool start/stop runs in every suite's setup; and katipo_async_failure_SUITE deliberately pins the crash/restart/terminate semantics the recent dispatch fixes rely on. The suites also pattern-match wpool_process's state record in several places, so a wrapper-shape change would have failed loudly rather than silently. On the OpenTelemetry side, the otel test group runs span and metrics assertions against the real 1.5.0 SDK.

Full Common Test suite (182 tests), dialyzer against a rebuilt PLT, xref, lint, and the hex package/docs build all pass on the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf2gxZLpxT4HvBfZKCgP3g
