### PR TITLE
feat: streaming responses with credit-based flow control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project are documented here. This project follows
   `{katipo_done, Ref, _}` instead of one buffered body.
   `cancel/2`, timeouts, and worker-death handling behave as for buffered
   async requests; synchronous functions reject the option.
+- Credit-based flow control for streamed responses: `stream_window => N`
+  pauses the transfer after `N` outstanding chunk messages (propagating
+  backpressure to the server) until `katipo:update_flow/3` grants more
+  credits. Defaults to `infinity`, the previous behavior.
 
 ### Fixed
 - When the Erlang-side request timer fires (the backstop behind curl's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project are documented here. This project follows
   versions within the published ranges: `worker_pool` 6.5.3 and
   `opentelemetry_api` 1.5.0 (previously locked to 6.0.1 and 1.4.0).
 
+### Added
+- Streaming responses: pass `stream => true` to any async function to
+  receive `{katipo_headers, Ref, _}`, then zero or more
+  `{katipo_chunk, Ref, Bin}` messages, then a terminal
+  `{katipo_done, Ref, _}` instead of one buffered body.
+  `cancel/2`, timeouts, and worker-death handling behave as for buffered
+  async requests; synchronous functions reject the option.
+
 ### Fixed
 - When the Erlang-side request timer fires (the backstop behind curl's own
   timeouts), the worker now aborts the still-running transfer in the C port

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ katipo:async_Method(Pool :: atom(), URL :: binary(), ReqOptions :: map()).
 katipo:await(Ref :: reference()).
 katipo:await(Ref :: reference(), Timeout :: timeout()).
 katipo:cancel(Pool :: atom(), Ref :: reference()).
+katipo:update_flow(Pool :: atom(), Ref :: reference(), Credits :: pos_integer()).
 
 ```
 
@@ -112,6 +113,8 @@ katipo:cancel(Pool :: atom(), Ref :: reference()).
 | `sslkey_blob`           | `binary()` (DER format)             | `undefined` | [docs](https://curl.se/libcurl/c/CURLOPT_SSLKEY_BLOB.html) curl >= 7.71.0      |
 | `keypasswd`             | `binary()`                          | `undefined` | [docs](https://curl.se/libcurl/c/CURLOPT_KEYPASSWD.html)                       |
 | `http_auth`             | `basic` <br> `digest` <br> `ntlm` <br> `negotiate` | `undefined` | [docs](https://curl.se/libcurl/c/CURLOPT_HTTPAUTH.html)                        |
+| `stream`                | `boolean()`                         | `false`     | async only; deliver the body incrementally (see Streaming responses)                |
+| `stream_window`         | `pos_integer()` \| `infinity`       | `infinity`  | chunk credits before the transfer pauses awaiting `update_flow/3`                   |
 | `username`              | `binary()`                          | `undefined` | [docs](https://curl.se/libcurl/c/CURLOPT_USERNAME.html)                        |
 | `password`              | `binary()`                          | `undefined` | [docs](https://curl.se/libcurl/c/CURLOPT_PASSWORD.html)                        |
 | `userpwd`               | `binary()`                          | `undefined` | [docs](https://curl.se/libcurl/c/CURLOPT_USERPWD.html)                         |
@@ -171,8 +174,19 @@ A `{katipo_error, Ref, ErrorMap}` message is terminal and can arrive at any
 point, including mid-body (e.g. a timeout). `cancel/2` works as usual; after
 it takes effect no further messages arrive. Streaming is async-only — the
 synchronous functions reject `stream => true` — and `await/1,2` does not
-apply. Chunks are delivered as fast as the transfer produces them; there is
-no flow control back to the server.
+apply.
+
+By default chunks arrive as fast as the transfer produces them. To bound the
+consumer's exposure, pass `stream_window => N`: after `N` outstanding chunk
+messages the transfer pauses client-side (curl stops reading the socket, so
+backpressure reaches the server through TCP or the HTTP/2/3 stream window)
+until `katipo:update_flow(Pool, Ref, Credits)` grants more. A window of `N`
+bounds buffered data to roughly `N` × 16KB (curl's write-buffer size) plus
+one pipe's worth. The request timer keeps running while a transfer is
+paused, so a consumer that stops granting credits eventually receives
+`operation_timedout`. Use a reasonably current libcurl when combining
+`stream_window` with HTTP/2/3 multiplexing — older releases could stall
+other streams sharing the connection while one stream is paused.
 
 #### Pool Options
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,27 @@ receive `{error, #{code => worker_died}}`; if an async request cannot be
 handed to a worker at all (it died and is being restarted), `async_req` itself
 returns `{error, #{code => worker_died}}` and no message is delivered.
 
+#### Streaming responses
+
+Pass `stream => true` to any async function to receive the body incrementally
+instead of as one buffered binary — useful for large downloads, where
+buffering costs roughly twice the body size across the port boundary:
+
+```erlang
+{ok, Ref} = katipo:async_get(Pool, Url, #{stream => true}),
+receive {katipo_headers, Ref, #{status := Status, headers := Headers}} -> ok end,
+collect(Ref) %% ->
+%%   {katipo_chunk, Ref, Bin}      zero or more, in arrival order
+%%   {katipo_done, Ref, #{status := Status, cookiejar := Jar}}  terminal
+```
+
+A `{katipo_error, Ref, ErrorMap}` message is terminal and can arrive at any
+point, including mid-body (e.g. a timeout). `cancel/2` works as usual; after
+it takes effect no further messages arrive. Streaming is async-only — the
+synchronous functions reject `stream => true` — and `await/1,2` does not
+apply. Chunks are delivered as fast as the transfer produces them; there is
+no flow control back to the server.
+
 #### Pool Options
 
 | Option                  | Type                          | Default      | Note                                                                                           |

--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -521,19 +521,26 @@ static void encode_headers(ei_x_buff *result, ConnInfo *conn) {
   }
 }
 
+/* Start a {Tag, {{Pid, Ref}, Payload}} message -- the envelope every
+ * message to Erlang shares; the caller appends the payload term. */
+static void begin_msg(ei_x_buff *result, const char *tag,
+                      erlang_pid *pid, erlang_ref *ref) {
+  if (ei_x_new_with_version(result) ||
+      ei_x_encode_tuple_header(result, 2) ||
+      ei_x_encode_atom(result, tag) ||
+      ei_x_encode_tuple_header(result, 2) ||
+      ei_x_encode_tuple_header(result, 2) ||
+      ei_x_encode_pid(result, pid) ||
+      ei_x_encode_ref(result, ref)) {
+    errx(2, "Failed to encode %s message envelope", tag);
+  }
+}
+
 static void send_ok_to_erlang(ConnInfo *conn) {
   ei_x_buff result;
 
-  if (ei_x_new_with_version(&result) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_atom(&result, "ok") ||
-      ei_x_encode_tuple_header(&result, 2) ||
-
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_pid(&result, conn->pid) ||
-      ei_x_encode_ref(&result, conn->ref) ||
-
-      ei_x_encode_tuple_header(&result, 5) ||
+  begin_msg(&result, "ok", conn->pid, conn->ref);
+  if (ei_x_encode_tuple_header(&result, 5) ||
       ei_x_encode_long(&result, conn->response_code) ||
       ei_x_encode_list_header(&result, conn->num_headers)) {
     errx(2, "Failed to encode &result");
@@ -558,18 +565,14 @@ static void send_ok_to_erlang(ConnInfo *conn) {
 static void send_headers_to_erlang(ConnInfo *conn) {
   ei_x_buff result;
 
-  curl_easy_getinfo(conn->easy, CURLINFO_RESPONSE_CODE, &conn->response_code);
+  /* Already fetched when we get here via check_multi_info (bodyless
+   * response); fetch for the usual first-body-byte path. */
+  if (conn->response_code == 0) {
+    curl_easy_getinfo(conn->easy, CURLINFO_RESPONSE_CODE, &conn->response_code);
+  }
 
-  if (ei_x_new_with_version(&result) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_atom(&result, "headers") ||
-      ei_x_encode_tuple_header(&result, 2) ||
-
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_pid(&result, conn->pid) ||
-      ei_x_encode_ref(&result, conn->ref) ||
-
-      ei_x_encode_tuple_header(&result, 2) ||
+  begin_msg(&result, "headers", conn->pid, conn->ref);
+  if (ei_x_encode_tuple_header(&result, 2) ||
       ei_x_encode_long(&result, conn->response_code) ||
       ei_x_encode_list_header(&result, conn->num_headers)) {
     errx(2, "Failed to encode headers message");
@@ -582,41 +585,42 @@ static void send_headers_to_erlang(ConnInfo *conn) {
   conn->headers_sent = 1;
 }
 
-/* Streaming: {chunk, {Pid, Ref}, Body} -- one per write callback. */
+/* Streaming: {chunk, {Pid, Ref}, Body} -- one per write callback. This is
+ * the per-16KB hot path, so the payload is written to the pipe straight
+ * from curl's buffer instead of being copied into the ei buffer first: the
+ * BINARY_EXT header (tag 109, 4-byte big-endian length) is appended to the
+ * small ei-encoded prefix by hand. */
 static void send_chunk_to_erlang(ConnInfo *conn, void *data, size_t len) {
-  ei_x_buff result;
+  ei_x_buff prefix;
+  char bin_hdr[5];
+  uint32_t nlen;
+  u_int32_t erl_pkt_len;
+  char size_buf[4];
 
-  if (ei_x_new_with_version(&result) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_atom(&result, "chunk") ||
-      ei_x_encode_tuple_header(&result, 2) ||
-
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_pid(&result, conn->pid) ||
-      ei_x_encode_ref(&result, conn->ref) ||
-
-      ei_x_encode_binary(&result, data, len)) {
-    errx(2, "Failed to encode chunk message");
+  begin_msg(&prefix, "chunk", conn->pid, conn->ref);
+  bin_hdr[0] = 109; /* BINARY_EXT */
+  nlen = htonl((uint32_t)len);
+  memcpy(bin_hdr + 1, &nlen, 4);
+  if (ei_x_append_buf(&prefix, bin_hdr, 5)) {
+    errx(2, "Failed to encode chunk header");
   }
 
-  send_to_erlang(conn->global, result.buff, result.index);
-  ei_x_free(&result);
+  erl_pkt_len = htonl((uint32_t)(prefix.index + len));
+  memcpy(size_buf, &erl_pkt_len, sizeof(size_buf));
+  if (bufferevent_write(conn->global->to_erlang, size_buf, sizeof(size_buf)) < 0 ||
+      bufferevent_write(conn->global->to_erlang, prefix.buff, prefix.index) < 0 ||
+      bufferevent_write(conn->global->to_erlang, data, len) < 0) {
+    errx(2, "bufferevent_write");
+  }
+  ei_x_free(&prefix);
 }
 
 /* Streaming: {done, {Pid, Ref}, {Status, CookieJar, Metrics}} -- terminal. */
 static void send_done_to_erlang(ConnInfo *conn) {
   ei_x_buff result;
 
-  if (ei_x_new_with_version(&result) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_atom(&result, "done") ||
-      ei_x_encode_tuple_header(&result, 2) ||
-
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_pid(&result, conn->pid) ||
-      ei_x_encode_ref(&result, conn->ref) ||
-
-      ei_x_encode_tuple_header(&result, 3) ||
+  begin_msg(&result, "done", conn->pid, conn->ref);
+  if (ei_x_encode_tuple_header(&result, 3) ||
       ei_x_encode_long(&result, conn->response_code)) {
     errx(2, "Failed to encode done message");
   }
@@ -640,14 +644,8 @@ static void send_error_to_erlang(CURLcode curl_code, ConnInfo *conn) {
   error_msg = conn->error[0] ? conn->error : curl_easy_strerror(curl_code);
   error_msg_len = strlen(error_msg);
 
-  if (ei_x_new_with_version(&result) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_atom(&result, "error") ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_pid(&result, conn->pid) ||
-      ei_x_encode_ref(&result, conn->ref) ||
-      ei_x_encode_tuple_header(&result, 3) ||
+  begin_msg(&result, "error", conn->pid, conn->ref);
+  if (ei_x_encode_tuple_header(&result, 3) ||
       ei_x_encode_atom(&result, error_code) ||
       ei_x_encode_binary(&result, error_msg, error_msg_len)) {
     errx(2, "Failed to encode result");
@@ -697,15 +695,25 @@ static void free_conn(GlobalInfo *global, ConnInfo *conn) {
   free(conn);
 }
 
+/* The in-flight transfer matching the {pid, ref} identity, or NULL if it
+ * already completed or was cancelled. */
+static ConnInfo *find_conn(GlobalInfo *global, erlang_pid *pid,
+                           erlang_ref *ref) {
+  for (ConnInfo *conn = global->active_conns; conn; conn = conn->next) {
+    if (ei_cmp_refs(conn->ref, ref) == 0 && ei_cmp_pids(conn->pid, pid) == 0) {
+      return conn;
+    }
+  }
+  return NULL;
+}
+
 /* Abort the in-flight transfer matching {pid, ref}, if we still have it. No
  * response is sent to Erlang -- the request is simply dropped. A no-op if the
  * request already completed (already removed from active_conns). */
 static void cancel_conn(GlobalInfo *global, erlang_pid *pid, erlang_ref *ref) {
-  for (ConnInfo *conn = global->active_conns; conn; conn = conn->next) {
-    if (ei_cmp_refs(conn->ref, ref) == 0 && ei_cmp_pids(conn->pid, pid) == 0) {
-      free_conn(global, conn);
-      return;
-    }
+  ConnInfo *conn = find_conn(global, pid, ref);
+  if (conn) {
+    free_conn(global, conn);
   }
 }
 
@@ -715,26 +723,22 @@ static void cancel_conn(GlobalInfo *global, erlang_pid *pid, erlang_ref *ref) {
 static void flow_conn(GlobalInfo *global, erlang_pid *pid, erlang_ref *ref,
                       long n) {
   CURLMcode rc;
+  ConnInfo *conn = find_conn(global, pid, ref);
 
-  for (ConnInfo *conn = global->active_conns; conn; conn = conn->next) {
-    if (ei_cmp_refs(conn->ref, ref) == 0 && ei_cmp_pids(conn->pid, pid) == 0) {
-      if (conn->window < 0 || n <= 0) {
-        return;
-      }
-      /* Credits first: curl may invoke write_cb synchronously inside
-       * curl_easy_pause to flush the buffer it held while paused. */
-      conn->window += n;
-      if (conn->paused) {
-        conn->paused = 0;
-        curl_easy_pause(conn->easy, CURLPAUSE_CONT);
-        /* Kick the multi so socket reading resumes promptly. */
-        rc = curl_multi_socket_action(global->multi, CURL_SOCKET_TIMEOUT, 0,
-                                      &global->still_running);
-        mcode_or_die("flow_conn: curl_multi_socket_action", rc);
-        check_multi_info(global);
-      }
-      return;
-    }
+  if (conn == NULL || conn->window < 0 || n <= 0) {
+    return;
+  }
+  /* Credits first: curl may invoke write_cb synchronously inside
+   * curl_easy_pause to flush the buffer it held while paused. */
+  conn->window += n;
+  if (conn->paused) {
+    conn->paused = 0;
+    curl_easy_pause(conn->easy, CURLPAUSE_CONT);
+    /* Kick the multi so socket reading resumes promptly. */
+    rc = curl_multi_socket_action(global->multi, CURL_SOCKET_TIMEOUT, 0,
+                                  &global->still_running);
+    mcode_or_die("flow_conn: curl_multi_socket_action", rc);
+    check_multi_info(global);
   }
 }
 
@@ -1161,14 +1165,8 @@ static void send_parse_error_to_erlang(GlobalInfo *global,
   ei_x_buff result;
   size_t msg_len = strlen(msg);
 
-  if (ei_x_new_with_version(&result) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_atom(&result, "error") ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_tuple_header(&result, 2) ||
-      ei_x_encode_pid(&result, pid) ||
-      ei_x_encode_ref(&result, ref) ||
-      ei_x_encode_tuple_header(&result, 3) ||
+  begin_msg(&result, "error", pid, ref);
+  if (ei_x_encode_tuple_header(&result, 3) ||
       ei_x_encode_atom(&result, "bad_opts") ||
       ei_x_encode_binary(&result, msg, msg_len) ||
       ei_x_encode_empty_list(&result)) {
@@ -1485,10 +1483,18 @@ static void erl_input(struct bufferevent *ev, void *arg) {
     }
 
     /* Cancel command: {Pid, Ref, cancel} (arity 3). Abort the matching
-     * in-flight transfer if we still have it; no response is sent. Requests
-     * are 8-tuples, so arity discriminates the command kinds. */
+     * in-flight transfer if we still have it; no response is sent.
+     * Commands are discriminated by arity plus their tag atom (requests
+     * are 8-tuples); malformed commands are dropped silently -- replying
+     * would be delivered as a terminal message for a healthy request. */
     if (arity == 3) {
-      cancel_conn(global, pid, ref);
+      char cancel_atom[MAXATOMLEN];
+      if (ei_decode_atom(buf, &index, cancel_atom) ||
+          strcmp(cancel_atom, "cancel") != 0) {
+        fprintf(stderr, "ERROR: Couldn't decode cancel command\n");
+      } else {
+        cancel_conn(global, pid, ref);
+      }
       free(pid);
       free(ref);
       free(buf);
@@ -1496,9 +1502,8 @@ static void erl_input(struct bufferevent *ev, void *arg) {
     }
 
     /* Flow command: {Pid, Ref, flow, N} (arity 4). Grant N more chunk
-     * credits to the matching streaming transfer. Malformed flow commands
-     * are dropped silently -- replying with a parse error would be
-     * delivered as a terminal message and kill a healthy stream. */
+     * credits to the matching streaming transfer. */
+
     if (arity == 4) {
       char flow_atom[MAXATOMLEN];
       long flow_n;

--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -51,6 +51,7 @@
 #define K_CURLOPT_DNS_CACHE_TIMEOUT 31
 #define K_CURLOPT_CA_CACHE_TIMEOUT 32
 #define K_CURLOPT_PIPEWAIT 33
+#define K_CURLOPT_STREAM 34
 
 #define K_CURLAUTH_BASIC 100
 #define K_CURLAUTH_DIGEST 101
@@ -90,6 +91,12 @@ typedef struct _ConnInfo {
   long response_code;
   char *post_data;
   long post_data_size;
+  /* Streaming (stream => true): body bytes are forwarded as they arrive
+   * instead of being buffered in `memory`. headers_sent tracks the one-time
+   * headers message that precedes the first chunk (or the done message for
+   * bodyless responses). */
+  int stream;
+  int headers_sent;
   // metrics
   double total_time;
   double namelookup_time;
@@ -140,6 +147,7 @@ typedef struct _EasyOpts {
   long curlopt_dns_cache_timeout;
   long curlopt_ca_cache_timeout;
   long curlopt_pipewait;
+  long curlopt_stream;
 } EasyOpts;
 
 static const char *curl_error_code(CURLcode error) {
@@ -537,6 +545,82 @@ static void send_ok_to_erlang(ConnInfo *conn) {
   ei_x_free(&result);
 }
 
+/* Streaming: {headers, {Pid, Ref}, {Status, Headers}} -- sent once, before
+ * the first chunk (or before done, for a bodyless response). */
+static void send_headers_to_erlang(ConnInfo *conn) {
+  ei_x_buff result;
+
+  curl_easy_getinfo(conn->easy, CURLINFO_RESPONSE_CODE, &conn->response_code);
+
+  if (ei_x_new_with_version(&result) ||
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_atom(&result, "headers") ||
+      ei_x_encode_tuple_header(&result, 2) ||
+
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_pid(&result, conn->pid) ||
+      ei_x_encode_ref(&result, conn->ref) ||
+
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_long(&result, conn->response_code) ||
+      ei_x_encode_list_header(&result, conn->num_headers)) {
+    errx(2, "Failed to encode headers message");
+  }
+
+  encode_headers(&result, conn);
+
+  send_to_erlang(conn->global, result.buff, result.index);
+  ei_x_free(&result);
+  conn->headers_sent = 1;
+}
+
+/* Streaming: {chunk, {Pid, Ref}, Body} -- one per write callback. */
+static void send_chunk_to_erlang(ConnInfo *conn, void *data, size_t len) {
+  ei_x_buff result;
+
+  if (ei_x_new_with_version(&result) ||
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_atom(&result, "chunk") ||
+      ei_x_encode_tuple_header(&result, 2) ||
+
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_pid(&result, conn->pid) ||
+      ei_x_encode_ref(&result, conn->ref) ||
+
+      ei_x_encode_binary(&result, data, len)) {
+    errx(2, "Failed to encode chunk message");
+  }
+
+  send_to_erlang(conn->global, result.buff, result.index);
+  ei_x_free(&result);
+}
+
+/* Streaming: {done, {Pid, Ref}, {Status, CookieJar, Metrics}} -- terminal. */
+static void send_done_to_erlang(ConnInfo *conn) {
+  ei_x_buff result;
+
+  if (ei_x_new_with_version(&result) ||
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_atom(&result, "done") ||
+      ei_x_encode_tuple_header(&result, 2) ||
+
+      ei_x_encode_tuple_header(&result, 2) ||
+      ei_x_encode_pid(&result, conn->pid) ||
+      ei_x_encode_ref(&result, conn->ref) ||
+
+      ei_x_encode_tuple_header(&result, 3) ||
+      ei_x_encode_long(&result, conn->response_code)) {
+    errx(2, "Failed to encode done message");
+  }
+
+  encode_cookies(&result, conn);
+
+  encode_metrics(&result, conn);
+
+  send_to_erlang(conn->global, result.buff, result.index);
+  ei_x_free(&result);
+}
+
 static void send_error_to_erlang(CURLcode curl_code, ConnInfo *conn) {
   ei_x_buff result;
   size_t error_msg_len;
@@ -639,7 +723,16 @@ static void check_multi_info(GlobalInfo *global) {
       curl_easy_getinfo(easy, CURLINFO_STARTTRANSFER_TIME, &conn->starttransfer_time);
 
       if (res == CURLE_OK) {
-        send_ok_to_erlang(conn);
+        if (conn->stream) {
+          /* A bodyless response never entered write_cb, so the headers
+           * message may still be owed before the terminal done. */
+          if (!conn->headers_sent) {
+            send_headers_to_erlang(conn);
+          }
+          send_done_to_erlang(conn);
+        } else {
+          send_ok_to_erlang(conn);
+        }
       } else {
         send_error_to_erlang(res, conn);
       }
@@ -742,6 +835,18 @@ static int multi_timer_cb(CURLM *multi, long timeout_ms, void *userp) {
 static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data) {
   size_t realsize = size * nmemb;
   ConnInfo *conn = (ConnInfo *)data;
+
+  /* Streaming transfers forward body bytes as they arrive instead of
+   * buffering them; the headers message goes out once, before the first
+   * chunk (by which point header_cb has seen the final response's header
+   * block, including after redirects). */
+  if (conn->stream) {
+    if (!conn->headers_sent) {
+      send_headers_to_erlang(conn);
+    }
+    send_chunk_to_erlang(conn, ptr, realsize);
+    return realsize;
+  }
 
   size_t needed = conn->size + realsize;
   if (needed > conn->capacity) {
@@ -856,6 +961,7 @@ static void new_conn(long method, char *url, struct curl_slist *req_headers,
   conn->req_cookies = req_cookies;
   conn->post_data = post_data;
   conn->post_data_size = post_data_size;
+  conn->stream = eopts.curlopt_stream != 0;
 
   #if LIBCURL_VERSION_NUM >= 0x075500 /* 7.85.0 */
     curl_easy_setopt(conn->easy, CURLOPT_PROTOCOLS_STR, "http,https");
@@ -1155,6 +1261,9 @@ static int parse_eopts(char *buf, int *index, EasyOpts *eopts) {
         break;
       case K_CURLOPT_PIPEWAIT:
         eopts->curlopt_pipewait = eopt_long;
+        break;
+      case K_CURLOPT_STREAM:
+        eopts->curlopt_stream = eopt_long;
         break;
       default:
         break;

--- a/c_src/katipo.c
+++ b/c_src/katipo.c
@@ -52,6 +52,7 @@
 #define K_CURLOPT_CA_CACHE_TIMEOUT 32
 #define K_CURLOPT_PIPEWAIT 33
 #define K_CURLOPT_STREAM 34
+#define K_CURLOPT_STREAM_WINDOW 35
 
 #define K_CURLAUTH_BASIC 100
 #define K_CURLAUTH_DIGEST 101
@@ -94,9 +95,13 @@ typedef struct _ConnInfo {
   /* Streaming (stream => true): body bytes are forwarded as they arrive
    * instead of being buffered in `memory`. headers_sent tracks the one-time
    * headers message that precedes the first chunk (or the done message for
-   * bodyless responses). */
+   * bodyless responses). window is the remaining chunk-message credits
+   * (-1 = unbounded); at zero the transfer is paused until the consumer
+   * grants more via a flow command. */
   int stream;
   int headers_sent;
+  long window;
+  int paused;
   // metrics
   double total_time;
   double namelookup_time;
@@ -148,6 +153,7 @@ typedef struct _EasyOpts {
   long curlopt_ca_cache_timeout;
   long curlopt_pipewait;
   long curlopt_stream;
+  long curlopt_stream_window;
 } EasyOpts;
 
 static const char *curl_error_code(CURLcode error) {
@@ -399,6 +405,8 @@ static const char *curl_error_code(CURLcode error) {
       return "unknown_error";
   }
 }
+
+static void check_multi_info(GlobalInfo *global);
 
 /* Die if we get a bad CURLMcode somewhere */
 static void mcode_or_die(const char *where, CURLMcode code) {
@@ -701,6 +709,35 @@ static void cancel_conn(GlobalInfo *global, erlang_pid *pid, erlang_ref *ref) {
   }
 }
 
+/* Grant n more chunk credits to the streaming transfer matching {pid, ref}
+ * and resume it if it was paused waiting for credits. A no-op if the
+ * transfer is gone (completed/cancelled) or was started unbounded. */
+static void flow_conn(GlobalInfo *global, erlang_pid *pid, erlang_ref *ref,
+                      long n) {
+  CURLMcode rc;
+
+  for (ConnInfo *conn = global->active_conns; conn; conn = conn->next) {
+    if (ei_cmp_refs(conn->ref, ref) == 0 && ei_cmp_pids(conn->pid, pid) == 0) {
+      if (conn->window < 0 || n <= 0) {
+        return;
+      }
+      /* Credits first: curl may invoke write_cb synchronously inside
+       * curl_easy_pause to flush the buffer it held while paused. */
+      conn->window += n;
+      if (conn->paused) {
+        conn->paused = 0;
+        curl_easy_pause(conn->easy, CURLPAUSE_CONT);
+        /* Kick the multi so socket reading resumes promptly. */
+        rc = curl_multi_socket_action(global->multi, CURL_SOCKET_TIMEOUT, 0,
+                                      &global->still_running);
+        mcode_or_die("flow_conn: curl_multi_socket_action", rc);
+        check_multi_info(global);
+      }
+      return;
+    }
+  }
+}
+
 static void check_multi_info(GlobalInfo *global) {
   CURLMsg *msg;
   int msgs_left;
@@ -841,10 +878,21 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data) {
    * chunk (by which point header_cb has seen the final response's header
    * block, including after redirects). */
   if (conn->stream) {
+    if (conn->window == 0) {
+      /* Out of credits: pause the transfer. curl keeps this buffer and
+       * re-delivers it after CURLPAUSE_CONT, so nothing is sent or counted
+       * now. Pausing stops socket reads, so backpressure reaches the
+       * server via TCP or the HTTP/2/3 stream window. */
+      conn->paused = 1;
+      return CURL_WRITEFUNC_PAUSE;
+    }
     if (!conn->headers_sent) {
       send_headers_to_erlang(conn);
     }
     send_chunk_to_erlang(conn, ptr, realsize);
+    if (conn->window > 0) {
+      conn->window--;
+    }
     return realsize;
   }
 
@@ -962,6 +1010,7 @@ static void new_conn(long method, char *url, struct curl_slist *req_headers,
   conn->post_data = post_data;
   conn->post_data_size = post_data_size;
   conn->stream = eopts.curlopt_stream != 0;
+  conn->window = eopts.curlopt_stream_window;
 
   #if LIBCURL_VERSION_NUM >= 0x075500 /* 7.85.0 */
     curl_easy_setopt(conn->easy, CURLOPT_PROTOCOLS_STR, "http,https");
@@ -1265,6 +1314,9 @@ static int parse_eopts(char *buf, int *index, EasyOpts *eopts) {
       case K_CURLOPT_STREAM:
         eopts->curlopt_stream = eopt_long;
         break;
+      case K_CURLOPT_STREAM_WINDOW:
+        eopts->curlopt_stream_window = eopt_long;
+        break;
       default:
         break;
       }
@@ -1434,9 +1486,29 @@ static void erl_input(struct bufferevent *ev, void *arg) {
 
     /* Cancel command: {Pid, Ref, cancel} (arity 3). Abort the matching
      * in-flight transfer if we still have it; no response is sent. Requests
-     * are 8-tuples, so arity discriminates the two. */
+     * are 8-tuples, so arity discriminates the command kinds. */
     if (arity == 3) {
       cancel_conn(global, pid, ref);
+      free(pid);
+      free(ref);
+      free(buf);
+      continue;
+    }
+
+    /* Flow command: {Pid, Ref, flow, N} (arity 4). Grant N more chunk
+     * credits to the matching streaming transfer. Malformed flow commands
+     * are dropped silently -- replying with a parse error would be
+     * delivered as a terminal message and kill a healthy stream. */
+    if (arity == 4) {
+      char flow_atom[MAXATOMLEN];
+      long flow_n;
+      if (ei_decode_atom(buf, &index, flow_atom) ||
+          strcmp(flow_atom, "flow") != 0 ||
+          ei_decode_long(buf, &index, &flow_n)) {
+        fprintf(stderr, "ERROR: Couldn't decode flow command\n");
+      } else {
+        flow_conn(global, pid, ref, flow_n);
+      }
       free(pid);
       free(ref);
       free(buf);
@@ -1483,6 +1555,7 @@ static void erl_input(struct bufferevent *ev, void *arg) {
         .curlopt_dns_cache_timeout = 60,
         .curlopt_ca_cache_timeout = 86400,
         .curlopt_pipewait = 1,
+        .curlopt_stream_window = -1,
     };
 
     if (parse_eopts(buf, &index, &eopts) != 0) {

--- a/formal/KatipoFixed.cfg
+++ b/formal/KatipoFixed.cfg
@@ -4,10 +4,12 @@ SPECIFICATION Spec
 CONSTANTS
   Refs = {r1, r2}
   MaxPortDeaths = 2
+  MaxChunks = 1
 INVARIANTS
   TypeOK
   AtMostOneDelivery
   NoDeliveryAfterEffectiveCancel
   NoCancelPollution
+  NoProgressAfterStop
 PROPERTIES
   EventualOutcome

--- a/formal/KatipoFixed.tla
+++ b/formal/KatipoFixed.tla
@@ -21,7 +21,8 @@ EXTENDS Naturals, Sequences, FiniteSets
 
 CONSTANTS
   Refs,          \* model values: one per async request
-  MaxPortDeaths  \* bound on spontaneous port deaths (state-space bound)
+  MaxPortDeaths, \* bound on spontaneous port deaths (state-space bound)
+  MaxChunks      \* bound on streaming progress messages per transfer
 
 VARIABLES
   wAlive,     \* worker process alive & registered
@@ -37,14 +38,19 @@ VARIABLES
   effCancel,  \* refs whose cancel was processed while the request was held
   effCancelSnap,   \* [Refs -> Nat] delivered[r] when the cancel took effect
   deaths,          \* port deaths so far
-  cancelPollution  \* TRUE if processing a cancel itself caused a delivery
+  cancelPollution, \* TRUE if processing a cancel itself caused a delivery
+  chunksEmitted,   \* [Refs -> Nat] streaming progress messages sent by port
+  progressStop     \* TRUE if a progress message was delivered after the
+                   \* request was cancelled or terminally resolved
 
 vars == <<wAlive, pAlive, wQ, pQ, reqs, timerFired, conns, sent, cancelled,
-          delivered, effCancel, effCancelSnap, deaths, cancelPollution>>
+          delivered, effCancel, effCancelSnap, deaths, cancelPollution,
+          chunksEmitted, progressStop>>
 
 ReqMsg(r)     == <<"req", r>>
 CancelMsg(r)  == <<"cancel", r>>
 RespMsg(r)    == <<"resp", r>>
+ChunkMsg(r)   == <<"chunk", r>>
 TimeoutMsg(r) == <<"timeout", r>>
 ExitMsg       == <<"exit">>
 
@@ -57,6 +63,8 @@ Init ==
   /\ effCancel = {} /\ effCancelSnap = [r \in Refs |-> 0]
   /\ deaths = 0
   /\ cancelPollution = FALSE
+  /\ chunksEmitted = [r \in Refs |-> 0]
+  /\ progressStop = FALSE
 
 \* Admission calls still sitting in a queue: when the worker dies, each
 \* caller's gen_server:call monitor fires and async_req returns
@@ -86,7 +94,7 @@ SendAsync(r) ==
      ELSE /\ delivered' = [delivered EXCEPT ![r] = @ + 1]
           /\ UNCHANGED wQ
   /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, timerFired, conns, cancelled,
-                 effCancel, effCancelSnap, deaths, cancelPollution>>
+                 effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 \* katipo:cancel/2 -> wpool:broadcast: still a cast, dropped if dead. Only
 \* refs whose admission call returned {ok, Ref} can be cancelled.
@@ -96,7 +104,7 @@ SendCancel(r) ==
   /\ cancelled' = cancelled \cup {r}
   /\ wQ' = IF wAlive THEN Append(wQ, CancelMsg(r)) ELSE wQ
   /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, timerFired, conns, sent,
-                 delivered, effCancel, effCancelSnap, deaths, cancelPollution>>
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 (* ----------------------------- worker ----------------------------------*)
 
@@ -113,12 +121,12 @@ WorkerRecvReq(r) ==
           /\ reqs' = reqs \cup {r}
           /\ UNCHANGED <<wAlive, pAlive, timerFired, conns, sent, cancelled,
                          delivered, effCancel, effCancelSnap, deaths,
-                         cancelPollution>>
+                         cancelPollution, chunksEmitted, progressStop>>
      ELSE /\ delivered' = CrashedDelivered(wQ)  \* includes r, still queued
           /\ wAlive' = FALSE /\ pAlive' = FALSE
           /\ wQ' = <<>> /\ pQ' = <<>> /\ reqs' = {} /\ conns' = {}
           /\ UNCHANGED <<timerFired, sent, cancelled, effCancel,
-                         effCancelSnap, deaths, cancelPollution>>
+                         effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 \* abort_transfer/2: best-effort port_command of the cancel tuple with
 \* badarg swallowed -- nothing to write if the port is dead. Shared by the
@@ -138,7 +146,7 @@ WorkerRecvCancel(r) ==
           /\ pQ' = AbortPQ(r)
      ELSE /\ UNCHANGED <<reqs, effCancel, effCancelSnap, pQ>>
   /\ UNCHANGED <<wAlive, pAlive, timerFired, conns, sent, cancelled,
-                 delivered, deaths, cancelPollution>>
+                 delivered, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 \* handle_info({Port, {data, ...}}): deliver iff still in Reqs, else drop.
 WorkerRecvResp(r) ==
@@ -149,7 +157,21 @@ WorkerRecvResp(r) ==
           /\ reqs' = reqs \ {r}
      ELSE UNCHANGED <<delivered, reqs>>
   /\ UNCHANGED <<wAlive, pAlive, pQ, timerFired, conns, sent, cancelled,
-                 effCancel, effCancelSnap, deaths, cancelPollution>>
+                 effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
+
+\* handle_info for a streaming progress message ({headers,...}/{chunk,...}):
+\* forwarded to the reply_to iff the request is still in Reqs, else dropped
+\* (timed out, cancelled, or already resolved). progressStop records the
+\* impossible-by-construction case of forwarding after cancel/terminal.
+WorkerRecvChunk(r) ==
+  /\ wAlive /\ wQ # <<>> /\ Head(wQ) = ChunkMsg(r)
+  /\ wQ' = Tail(wQ)
+  /\ IF r \in reqs
+     THEN progressStop' = progressStop \/ r \in effCancel \/ delivered[r] > 0
+     ELSE UNCHANGED progressStop
+  /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, timerFired, conns, sent, cancelled,
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution,
+                 chunksEmitted>>
 
 \* handle_info({timeout, Tref, {req_timeout, From}}): deliver iff in Reqs,
 \* and abort_transfer the still-running transfer in the port.
@@ -162,7 +184,7 @@ WorkerRecvTimeout(r) ==
           /\ pQ' = AbortPQ(r)
      ELSE UNCHANGED <<delivered, reqs, pQ>>
   /\ UNCHANGED <<wAlive, pAlive, timerFired, conns, sent, cancelled,
-                 effCancel, effCancelSnap, deaths, cancelPollution>>
+                 effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 \* handle_info({'EXIT', Port, _}) -> {stop, port_died} -> terminate/2.
 \* Queued admission calls error out via their monitors.
@@ -172,21 +194,21 @@ WorkerRecvExit ==
   /\ wAlive' = FALSE /\ pAlive' = FALSE
   /\ wQ' = <<>> /\ pQ' = <<>> /\ reqs' = {} /\ conns' = {}
   /\ UNCHANGED <<timerFired, sent, cancelled, effCancel, effCancelSnap,
-                 deaths, cancelPollution>>
+                 deaths, cancelPollution, chunksEmitted, progressStop>>
 
 TimerFire(r) ==
   /\ wAlive /\ r \in reqs /\ r \notin timerFired
   /\ timerFired' = timerFired \cup {r}
   /\ wQ' = Append(wQ, TimeoutMsg(r))
   /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, conns, sent, cancelled,
-                 delivered, effCancel, effCancelSnap, deaths, cancelPollution>>
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 WorkerRestart ==
   /\ ~wAlive
   /\ wAlive' = TRUE /\ pAlive' = TRUE
   /\ wQ' = <<>> /\ pQ' = <<>> /\ reqs' = {} /\ conns' = {}
   /\ UNCHANGED <<timerFired, sent, cancelled, delivered, effCancel,
-                 effCancelSnap, deaths, cancelPollution>>
+                 effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 (* ----------------------------- C port -----------------------------------*)
 
@@ -195,21 +217,32 @@ PortRecvReq(r) ==
   /\ pQ' = Tail(pQ)
   /\ conns' = conns \cup {r}
   /\ UNCHANGED <<wAlive, pAlive, wQ, reqs, timerFired, sent, cancelled,
-                 delivered, effCancel, effCancelSnap, deaths, cancelPollution>>
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 PortRecvCancel(r) ==
   /\ pAlive /\ pQ # <<>> /\ Head(pQ) = CancelMsg(r)
   /\ pQ' = Tail(pQ)
   /\ conns' = conns \ {r}
   /\ UNCHANGED <<wAlive, pAlive, wQ, reqs, timerFired, sent, cancelled,
-                 delivered, effCancel, effCancelSnap, deaths, cancelPollution>>
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
+
+\* write_cb on a streaming transfer: forward a body chunk (headers behave
+\* identically and are folded into the same message kind). Bounded per
+\* transfer to keep the state space finite.
+PortEmitChunk(r) ==
+  /\ pAlive /\ r \in conns /\ chunksEmitted[r] < MaxChunks
+  /\ chunksEmitted' = [chunksEmitted EXCEPT ![r] = @ + 1]
+  /\ wQ' = Append(wQ, ChunkMsg(r))
+  /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, timerFired, conns, sent, cancelled,
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution,
+                 progressStop>>
 
 PortComplete(r) ==
   /\ pAlive /\ r \in conns
   /\ conns' = conns \ {r}
   /\ wQ' = Append(wQ, RespMsg(r))
   /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, timerFired, sent, cancelled,
-                 delivered, effCancel, effCancelSnap, deaths, cancelPollution>>
+                 delivered, effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
 PortDies ==
   /\ wAlive /\ pAlive /\ deaths < MaxPortDeaths
@@ -218,19 +251,21 @@ PortDies ==
   /\ conns' = {} /\ pQ' = <<>>
   /\ wQ' = Append(wQ, ExitMsg)
   /\ UNCHANGED <<wAlive, reqs, timerFired, sent, cancelled, delivered,
-                 effCancel, effCancelSnap, cancelPollution>>
+                 effCancel, effCancelSnap, cancelPollution, chunksEmitted, progressStop>>
 
 (* ----------------------------- spec -------------------------------------*)
 
 WorkerDispatch ==
   \/ \E r \in Refs: WorkerRecvReq(r) \/ WorkerRecvCancel(r)
                  \/ WorkerRecvResp(r) \/ WorkerRecvTimeout(r)
+                 \/ WorkerRecvChunk(r)
   \/ WorkerRecvExit
 
 PortDispatch == \E r \in Refs: PortRecvReq(r) \/ PortRecvCancel(r)
 
 Environment ==
   \/ \E r \in Refs: SendAsync(r) \/ SendCancel(r) \/ PortComplete(r)
+                  \/ PortEmitChunk(r)
   \/ PortDies
 
 Next ==
@@ -265,6 +300,10 @@ NoDeliveryAfterEffectiveCancel ==
   \A r \in effCancel: delivered[r] = effCancelSnap[r]
 
 NoCancelPollution == cancelPollution = FALSE
+
+\* Safety: no streaming progress message reaches the caller after the
+\* request was cancelled or terminally resolved.
+NoProgressAfterStop == progressStop = FALSE
 
 EventualOutcome ==
   \A r \in Refs: (r \in sent) ~> (delivered[r] > 0 \/ r \in cancelled)

--- a/formal/KatipoFixed.tla
+++ b/formal/KatipoFixed.tla
@@ -16,6 +16,14 @@
 (* See Katipo.tla for the pre-fix model, whose counterexamples motivated   *)
 (* these changes; all properties that failed there are expected to hold    *)
 (* here.                                                                   *)
+(*                                                                         *)
+(* Streaming flow control (stream_window/update_flow) is not modeled       *)
+(* explicitly: credits only gate when the port may emit a progress message *)
+(* (a strict restriction of PortEmitChunk below) and flow commands only    *)
+(* increment a port-side counter, so it removes behaviors from this spec   *)
+(* without adding caller-facing message kinds. Safety properties are       *)
+(* preserved under behavior restriction, and EventualOutcome does not      *)
+(* depend on chunk emission (a stalled transfer resolves via TimerFire).   *)
 (***************************************************************************)
 EXTENDS Naturals, Sequences, FiniteSets
 

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -48,6 +48,10 @@ restarted), the async function returns `{error, #{code => worker_died}}`
 instead of `{ok, Ref}` -- an accepted request always produces exactly one
 terminal message.
 
+With `stream => true` the body is delivered incrementally as
+`{katipo_headers, Ref, _}`, `{katipo_chunk, Ref, _}`* and a terminal
+`{katipo_done, Ref, _}` instead of one buffered response; see `async_req/2`.
+
 Async requests emit the same OTel span (`HTTP <METHOD>`, parented to the
 caller's context) and metrics as their synchronous counterparts; the span
 covers the full request and is finished when the response, a timeout, or a
@@ -271,6 +275,10 @@ async_delete(PoolName, Url, Opts) ->
 req(PoolName, Opts)
   when is_map(Opts) ->
     case katipo_req:build_req(Opts) of
+        {ok, #req{stream = ?STREAM_TRUE}} ->
+            %% A streamed response has no single reply to return; it only
+            %% makes sense as a message flow, i.e. via async_req/2.
+            {error, katipo_req:error_map(bad_opts, <<"[{stream,true}]">>)};
         {ok, Req} ->
             do_req_with_span(PoolName, Req);
         {error, _} = Error ->
@@ -288,6 +296,28 @@ request (e.g. it died and is being restarted), returns
 `{error, #{code => worker_died}}` and no message is delivered.
 
 Use `await/1,2` to block until the response arrives.
+
+With `stream => true` the response body is delivered incrementally instead of
+as one buffered binary. The message flow is:
+
+```erlang
+{katipo_headers, Ref, #{status := pos_integer(), headers := headers()}}
+{katipo_chunk, Ref, binary()}     %% zero or more, in order
+{katipo_done, Ref, #{status := pos_integer(), cookiejar := cookiejar()}}
+```
+
+A `{katipo_error, Ref, ErrorMap}` message is terminal and can arrive at any
+point, including after headers and chunks (e.g. a request timeout mid-body).
+`cancel/2` works as for buffered async requests. `await/1,2` does not apply
+to streamed requests; receive the messages directly. Streaming is only
+available through the async API -- `req/2` and the synchronous wrappers
+reject `stream => true`.
+
+Caveat shared with buffered mode: when following redirects
+(`followlocation => true`), a redirect response that itself carries a body
+surfaces that body through the write path -- in streaming form the
+`katipo_headers` message may then describe the redirect response rather
+than the final one. Real-world redirect responses rarely carry bodies.
 """.
 -spec async_req(katipo_pool:name(), request()) -> async_response().
 async_req(PoolName, Opts)

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -275,11 +275,7 @@ async_delete(PoolName, Url, Opts) ->
 -spec req(katipo_pool:name(), request()) -> response().
 req(PoolName, Opts)
   when is_map(Opts) ->
-    case katipo_req:build_req(Opts) of
-        {ok, #req{stream = ?STREAM_TRUE}} ->
-            %% A streamed response has no single reply to return; it only
-            %% makes sense as a message flow, i.e. via async_req/2.
-            {error, katipo_req:error_map(bad_opts, <<"[{stream,true}]">>)};
+    case katipo_req:build_req(Opts, sync) of
         {ok, Req} ->
             do_req_with_span(PoolName, Req);
         {error, _} = Error ->
@@ -339,7 +335,7 @@ async_req(PoolName, Opts)
         false ->
             {error, katipo_req:error_map(bad_opts, <<"[{reply_to,invalid}]">>)};
         true ->
-            case katipo_req:build_req(Opts2) of
+            case katipo_req:build_req(Opts2, async) of
                 {ok, Req} ->
                     UserRef = make_ref(),
                     Obs = katipo_span:start_async(katipo_req:method_int_to_binary(Req#req.method),
@@ -368,7 +364,8 @@ dispatch_async(PoolName, ReplyTo, UserRef, Req, Obs) ->
 Grants `N` more chunk-message credits to the streaming request `Ref`, which
 must have been started with a bounded `stream_window`. Best-effort like
 `cancel/2`: granting credits to an unknown, completed, or unbounded-window
-request is a harmless no-op.
+request is a harmless no-op. Each grant is a pool-wide broadcast, so grant
+in batches (e.g. half the window at a time) rather than per-chunk.
 """.
 -spec update_flow(katipo_pool:name(), reference(), pos_integer()) -> ok.
 update_flow(PoolName, Ref, N) when is_integer(N) andalso N > 0 ->
@@ -451,7 +448,12 @@ pool_call(PoolName, Msg) ->
             {error, katipo_req:error_map(worker_died, <<>>)}
     end.
 
--doc "Validates request options without performing the request.".
+-doc """
+Validates request options without performing the request. Cross-field rules
+are checked under the async API's rules (the superset): `stream => true`
+passes here but is additionally rejected by `req/2` and the synchronous
+wrappers.
+""".
 -spec check_opts(request()) -> ok | {error, map()}.
 check_opts(Opts) when is_map(Opts) ->
     katipo_req:check_opts(Opts).

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -94,6 +94,7 @@ worker failure arrives.
 -export([await/1]).
 -export([await/2]).
 -export([cancel/2]).
+-export([update_flow/3]).
 
 -export([check_opts/1]).
 
@@ -313,6 +314,13 @@ to streamed requests; receive the messages directly. Streaming is only
 available through the async API -- `req/2` and the synchronous wrappers
 reject `stream => true`.
 
+By default chunks are delivered as fast as the transfer produces them. Pass
+`stream_window => N` to bound that: the transfer pauses (propagating
+backpressure to the server via TCP or the HTTP/2/3 stream window) once `N`
+chunk messages are outstanding, and `update_flow/3` grants more. The request
+timer keeps running while a transfer is paused, so a consumer that stops
+granting credits eventually receives `operation_timedout`.
+
 Caveat shared with buffered mode: when following redirects
 (`followlocation => true`), a redirect response that itself carries a body
 surfaces that body through the write path -- in streaming form the
@@ -355,6 +363,17 @@ dispatch_async(PoolName, ReplyTo, UserRef, Req, Obs) ->
             katipo_span:finish_async(Obs, error, Error, []),
             {error, Error}
     end.
+
+-doc """
+Grants `N` more chunk-message credits to the streaming request `Ref`, which
+must have been started with a bounded `stream_window`. Best-effort like
+`cancel/2`: granting credits to an unknown, completed, or unbounded-window
+request is a harmless no-op.
+""".
+-spec update_flow(katipo_pool:name(), reference(), pos_integer()) -> ok.
+update_flow(PoolName, Ref, N) when is_integer(N) andalso N > 0 ->
+    wpool:broadcast(PoolName, {flow, Ref, N}),
+    ok.
 
 -doc #{equiv => await/2}.
 -spec await(reference()) -> response().

--- a/src/katipo_internal.hrl
+++ b/src/katipo_internal.hrl
@@ -76,6 +76,7 @@
 -define(CA_CACHE_TIMEOUT, 32).
 -define(PIPEWAIT, 33).
 -define(STREAM, 34).
+-define(STREAM_WINDOW, 35).
 
 -define(DEFAULT_REQ_TIMEOUT, 30000).
 -define(FOLLOWLOCATION_TRUE, 1).
@@ -97,6 +98,7 @@
 -define(PIPEWAIT_FALSE, 0).
 -define(STREAM_TRUE, 1).
 -define(STREAM_FALSE, 0).
+-define(STREAM_WINDOW_UNLIMITED, -1).
 
 %% CURLOPT_HTTP_VERSION values
 -define(CURL_HTTP_VERSION_NONE, 0).
@@ -162,7 +164,8 @@
           dns_cache_timeout = 60 :: integer(),
           ca_cache_timeout = 86400 :: integer(),
           pipewait = ?PIPEWAIT_TRUE :: ?PIPEWAIT_FALSE | ?PIPEWAIT_TRUE,
-          stream = ?STREAM_FALSE :: ?STREAM_FALSE | ?STREAM_TRUE
+          stream = ?STREAM_FALSE :: ?STREAM_FALSE | ?STREAM_TRUE,
+          stream_window = ?STREAM_WINDOW_UNLIMITED :: integer()
          }).
 
 -endif.

--- a/src/katipo_internal.hrl
+++ b/src/katipo_internal.hrl
@@ -75,6 +75,7 @@
 -define(DNS_CACHE_TIMEOUT, 31).
 -define(CA_CACHE_TIMEOUT, 32).
 -define(PIPEWAIT, 33).
+-define(STREAM, 34).
 
 -define(DEFAULT_REQ_TIMEOUT, 30000).
 -define(FOLLOWLOCATION_TRUE, 1).
@@ -94,6 +95,8 @@
 -define(VERBOSE_FALSE, 0).
 -define(PIPEWAIT_TRUE, 1).
 -define(PIPEWAIT_FALSE, 0).
+-define(STREAM_TRUE, 1).
+-define(STREAM_FALSE, 0).
 
 %% CURLOPT_HTTP_VERSION values
 -define(CURL_HTTP_VERSION_NONE, 0).
@@ -158,7 +161,8 @@
           userpwd = undefined :: undefined | binary(),
           dns_cache_timeout = 60 :: integer(),
           ca_cache_timeout = 86400 :: integer(),
-          pipewait = ?PIPEWAIT_TRUE :: ?PIPEWAIT_FALSE | ?PIPEWAIT_TRUE
+          pipewait = ?PIPEWAIT_TRUE :: ?PIPEWAIT_FALSE | ?PIPEWAIT_TRUE,
+          stream = ?STREAM_FALSE :: ?STREAM_FALSE | ?STREAM_TRUE
          }).
 
 -endif.

--- a/src/katipo_req.erl
+++ b/src/katipo_req.erl
@@ -237,6 +237,10 @@ opt(pipewait, true, {Req, Errors}) ->
     {Req#req{pipewait = ?PIPEWAIT_TRUE}, Errors};
 opt(pipewait, false, {Req, Errors}) ->
     {Req#req{pipewait = ?PIPEWAIT_FALSE}, Errors};
+opt(stream, true, {Req, Errors}) ->
+    {Req#req{stream = ?STREAM_TRUE}, Errors};
+opt(stream, false, {Req, Errors}) ->
+    {Req#req{stream = ?STREAM_FALSE}, Errors};
 opt(reply_to, Pid, {Req, Errors}) when is_pid(Pid) ->
     {Req, Errors};
 opt(K, V, {Req, Errors}) ->

--- a/src/katipo_req.erl
+++ b/src/katipo_req.erl
@@ -241,6 +241,10 @@ opt(stream, true, {Req, Errors}) ->
     {Req#req{stream = ?STREAM_TRUE}, Errors};
 opt(stream, false, {Req, Errors}) ->
     {Req#req{stream = ?STREAM_FALSE}, Errors};
+opt(stream_window, infinity, {Req, Errors}) ->
+    {Req#req{stream_window = ?STREAM_WINDOW_UNLIMITED}, Errors};
+opt(stream_window, N, {Req, Errors}) when is_integer(N) andalso N > 0 ->
+    {Req#req{stream_window = N}, Errors};
 opt(reply_to, Pid, {Req, Errors}) when is_pid(Pid) ->
     {Req, Errors};
 opt(K, V, {Req, Errors}) ->

--- a/src/katipo_req.erl
+++ b/src/katipo_req.erl
@@ -7,7 +7,7 @@
 %% encoding, header formatting, and the method<->code conversions. Factored out
 %% of katipo to keep the public facade small.
 
--export([build_req/1]).
+-export([build_req/2]).
 -export([check_opts/1]).
 -export([get_timeout/1]).
 -export([method_int_to_binary/1]).
@@ -23,23 +23,43 @@
 -dialyzer({nowarn_function, opt/3}).
 
 %% Build a validated, timeout-stamped #req{} from an opts map. Shared by the
-%% sync req/2 and async_req/2 entry points.
--spec build_req(katipo:request()) -> {ok, req()} | {error, map()}.
-build_req(Opts) ->
+%% sync req/2 and async_req/2 entry points; Mode carries the cross-field
+%% rules that depend on the caller: a streamed response has no single reply
+%% to return, so `stream` is only valid on the async path, and a
+%% `stream_window` only means something on a streaming request.
+-spec build_req(katipo:request(), sync | async) -> {ok, req()} | {error, map()}.
+build_req(Opts, Mode) ->
     case process_opts(Opts) of
         {ok, #req{url = undefined}} ->
             {error, error_map(bad_opts, <<"[{url,undefined}]">>)};
         {ok, Req} ->
-            {ok, Req#req{timeout = ?MODULE:get_timeout(Req)}};
+            case stream_opts_error(Req, Mode) of
+                ok ->
+                    {ok, Req#req{timeout = ?MODULE:get_timeout(Req)}};
+                {error, _} = Error ->
+                    Error
+            end;
         {error, _} = Error ->
             Error
     end.
 
+%% The cross-field stream rules, shared with check_opts/1 so pre-validation
+%% agrees with the request entry points.
+stream_opts_error(#req{stream = ?STREAM_TRUE}, sync) ->
+    {error, error_map(bad_opts, [{stream, true}])};
+stream_opts_error(#req{stream = ?STREAM_FALSE, stream_window = W}, _Mode)
+  when W =/= ?STREAM_WINDOW_UNLIMITED ->
+    {error, error_map(bad_opts, [{stream_window, W}])};
+stream_opts_error(#req{}, _Mode) ->
+    ok.
+
+%% Validates under the async rules (the superset: `stream` is accepted);
+%% cross-field checks match what req/2 and async_req/2 enforce.
 -spec check_opts(katipo:request()) -> ok | {error, map()}.
 check_opts(Opts) when is_map(Opts) ->
     case process_opts(Opts) of
-        {ok, _} ->
-            ok;
+        {ok, Req} ->
+            stream_opts_error(Req, async);
         {error, _} = Error ->
             Error
     end.

--- a/src/katipo_types.hrl
+++ b/src/katipo_types.hrl
@@ -185,7 +185,8 @@
                     userpwd => userpwd(),
                     dns_cache_timeout => integer(),
                     ca_cache_timeout => integer(),
-                    pipewait => boolean()}.
+                    pipewait => boolean(),
+                    stream => boolean()}.
 -type opts() :: #{reply_to => pid(),
                     headers => headers(),
                     cookiejar => cookiejar(),
@@ -216,7 +217,8 @@
                     userpwd => userpwd(),
                     dns_cache_timeout => integer(),
                     ca_cache_timeout => integer(),
-                    pipewait => boolean()}.
+                    pipewait => boolean(),
+                    stream => boolean()}.
 -export_type([opts/0]).
 -type metrics() :: proplists:proplist().
 -type response() :: {ok, #{status := status(),

--- a/src/katipo_types.hrl
+++ b/src/katipo_types.hrl
@@ -186,7 +186,8 @@
                     dns_cache_timeout => integer(),
                     ca_cache_timeout => integer(),
                     pipewait => boolean(),
-                    stream => boolean()}.
+                    stream => boolean(),
+                    stream_window => pos_integer() | infinity}.
 -type opts() :: #{reply_to => pid(),
                     headers => headers(),
                     cookiejar => cookiejar(),
@@ -218,7 +219,8 @@
                     dns_cache_timeout => integer(),
                     ca_cache_timeout => integer(),
                     pipewait => boolean(),
-                    stream => boolean()}.
+                    stream => boolean(),
+                    stream_window => pos_integer() | infinity}.
 -export_type([opts/0]).
 -type metrics() :: proplists:proplist().
 -type response() :: {ok, #{status := status(),

--- a/src/katipo_worker.erl
+++ b/src/katipo_worker.erl
@@ -102,34 +102,31 @@ handle_port_msg({error, {From, {Code, Message, Metrics}}}, Reqs) ->
     Error = #{code => Code, message => Message},
     finish_req(From, error, {Error, Metrics}, Reqs);
 handle_port_msg({headers, {From, {Status, Headers}}}, Reqs) ->
-    _ = case maps:find(From, Reqs) of
-            {ok, {_Tref, {async, ReplyTo, UserRef, _Obs}}} ->
-                ReplyTo ! {katipo_headers, UserRef,
-                           #{status => Status,
-                             headers => parse_headers(Headers)}};
-            _ ->
-                ok
-        end,
-    Reqs;
+    forward_progress(From, Reqs,
+                     fun(UserRef) ->
+                             {katipo_headers, UserRef,
+                              #{status => Status,
+                                headers => parse_headers(Headers)}}
+                     end);
 handle_port_msg({chunk, {From, Body}}, Reqs) ->
+    forward_progress(From, Reqs,
+                     fun(UserRef) -> {katipo_chunk, UserRef, Body} end);
+handle_port_msg({done, {From, {Status, CookieJar, Metrics}}}, Reqs) ->
+    Done = #{status => Status, cookiejar => CookieJar},
+    finish_req(From, done, {Done, Metrics}, Reqs).
+
+%% Progress messages forward to the async reply_to iff the request is still
+%% in flight; otherwise they are dropped silently (the request timed out,
+%% was cancelled, or already completed). The message is only built when it
+%% will be sent.
+forward_progress(From, Reqs, BuildMsg) ->
     _ = case maps:find(From, Reqs) of
             {ok, {_Tref, {async, ReplyTo, UserRef, _Obs}}} ->
-                ReplyTo ! {katipo_chunk, UserRef, Body};
+                ReplyTo ! BuildMsg(UserRef);
             _ ->
                 ok
         end,
-    Reqs;
-handle_port_msg({done, {From, {Status, CookieJar, Metrics}}}, Reqs) ->
-    case maps:find(From, Reqs) of
-        {ok, {Tref, {async, ReplyTo, UserRef, Obs}}} ->
-            _ = erlang:cancel_timer(Tref),
-            ReplyTo ! {katipo_done, UserRef,
-                       #{status => Status, cookiejar => CookieJar}},
-            katipo_span:finish_async(Obs, ok, #{status => Status}, Metrics),
-            maps:remove(From, Reqs);
-        _ ->
-            Reqs
-    end.
+    Reqs.
 
 %% Resolve a request with its terminal result, if it is still in flight.
 finish_req(From, Result, Response, Reqs) ->
@@ -142,8 +139,13 @@ finish_req(From, Result, Response, Reqs) ->
         end,
     maps:remove(From, Reqs).
 
-%% Deliver a completed response to a sync caller (via gen_server:reply) or an
-%% async ReplyTo (via a flattened katipo_response/katipo_error message).
+%% Deliver a terminal outcome to a sync caller (via gen_server:reply) or an
+%% async ReplyTo (via a flattened katipo_response/katipo_error/katipo_done
+%% message). `done` only occurs for streaming requests, which are async by
+%% construction.
+deliver({async, ReplyTo, UserRef, Obs}, _From, done, {DoneMap, Metrics}) ->
+    ReplyTo ! {katipo_done, UserRef, DoneMap},
+    katipo_span:finish_async(Obs, ok, DoneMap, Metrics);
 deliver(sync, From, Result, Response) ->
     gen_server:reply(From, {Result, Response});
 deliver({async, ReplyTo, UserRef, Obs}, _From, Result, {ResponseMap, Metrics}) ->
@@ -236,10 +238,16 @@ port_cmd(Port, Tuple) ->
     ok.
 
 find_async(UserRef, Reqs) ->
-    case [{From, Tref, Obs}
-          || From := {Tref, {async, _ReplyTo, UR, Obs}} <- Reqs, UR =:= UserRef] of
-        [{From, Tref, Obs} | _] -> {ok, From, Tref, Obs};
-        [] -> error
+    find_async_iter(UserRef, maps:iterator(Reqs)).
+
+find_async_iter(UserRef, Iter) ->
+    case maps:next(Iter) of
+        {From, {Tref, {async, _ReplyTo, UserRef, Obs}}, _Rest} ->
+            {ok, From, Tref, Obs};
+        {_From, _Value, Rest} ->
+            find_async_iter(UserRef, Rest);
+        none ->
+            error
     end.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/katipo_worker.erl
+++ b/src/katipo_worker.erl
@@ -76,6 +76,62 @@ handle_cast(Msg, State) ->
     logger:error("Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
+%% One decoded message from the C port. Terminal messages ({ok, ...},
+%% {error, ...}, {done, ...}) resolve the request: cancel its timer, deliver,
+%% and drop it from Reqs. Streaming progress messages ({headers, ...},
+%% {chunk, ...}) are forwarded to the async reply_to and leave the request in
+%% flight. Any message whose From is no longer in Reqs is dropped silently --
+%% the request timed out, was cancelled, or already completed.
+handle_port_msg({ok, {From, {Status, Headers, CookieJar, Body, Metrics}}}, Reqs) ->
+    R = #{status => Status,
+          headers => parse_headers(Headers),
+          cookiejar => CookieJar,
+          body => Body},
+    finish_req(From, ok, {R, Metrics}, Reqs);
+handle_port_msg({error, {From, {Code, Message, Metrics}}}, Reqs) ->
+    Error = #{code => Code, message => Message},
+    finish_req(From, error, {Error, Metrics}, Reqs);
+handle_port_msg({headers, {From, {Status, Headers}}}, Reqs) ->
+    _ = case maps:find(From, Reqs) of
+            {ok, {_Tref, {async, ReplyTo, UserRef, _Obs}}} ->
+                ReplyTo ! {katipo_headers, UserRef,
+                           #{status => Status,
+                             headers => parse_headers(Headers)}};
+            _ ->
+                ok
+        end,
+    Reqs;
+handle_port_msg({chunk, {From, Body}}, Reqs) ->
+    _ = case maps:find(From, Reqs) of
+            {ok, {_Tref, {async, ReplyTo, UserRef, _Obs}}} ->
+                ReplyTo ! {katipo_chunk, UserRef, Body};
+            _ ->
+                ok
+        end,
+    Reqs;
+handle_port_msg({done, {From, {Status, CookieJar, Metrics}}}, Reqs) ->
+    case maps:find(From, Reqs) of
+        {ok, {Tref, {async, ReplyTo, UserRef, Obs}}} ->
+            _ = erlang:cancel_timer(Tref),
+            ReplyTo ! {katipo_done, UserRef,
+                       #{status => Status, cookiejar => CookieJar}},
+            katipo_span:finish_async(Obs, ok, #{status => Status}, Metrics),
+            maps:remove(From, Reqs);
+        _ ->
+            Reqs
+    end.
+
+%% Resolve a request with its terminal result, if it is still in flight.
+finish_req(From, Result, Response, Reqs) ->
+    _ = case maps:find(From, Reqs) of
+            {ok, {Tref, Kind}} ->
+                _ = erlang:cancel_timer(Tref),
+                deliver(Kind, From, Result, Response);
+            error ->
+                ok
+        end,
+    maps:remove(From, Reqs).
+
 %% Deliver a completed response to a sync caller (via gen_server:reply) or an
 %% async ReplyTo (via a flattened katipo_response/katipo_error message).
 deliver(sync, From, Result, Response) ->
@@ -98,26 +154,7 @@ deliver_error({async, ReplyTo, UserRef, Obs}, _From, Error) ->
     katipo_span:finish_async(Obs, error, Error, []).
 
 handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
-    {Result, {From, Response}} =
-        case binary_to_term(Data) of
-            {ok, {From0, {Status, Headers, CookieJar, Body, Metrics}}} ->
-                R = #{status => Status,
-                      headers => parse_headers(Headers),
-                      cookiejar => CookieJar,
-                      body => Body},
-                {ok, {From0, {R, Metrics}}};
-            {error, {From0, {Code, Message, Metrics}}} ->
-                Error = #{code => Code, message => Message},
-                {error, {From0, {Error, Metrics}}}
-        end,
-    _ = case maps:find(From, Reqs) of
-        {ok, {Tref, Kind}} ->
-            _ = erlang:cancel_timer(Tref),
-            deliver(Kind, From, Result, Response);
-        error ->
-            ok
-    end,
-    Reqs2 = maps:remove(From, Reqs),
+    Reqs2 = handle_port_msg(binary_to_term(Data), Reqs),
     {noreply, State#state{reqs = Reqs2}};
 handle_info({timeout, Tref, {req_timeout, From}},
             State = #state{port = Port, reqs = Reqs}) ->
@@ -226,7 +263,8 @@ send_to_port(Port, {Self, Ref},
                   userpwd = UserPwd,
                   dns_cache_timeout = DNSCacheTimeout,
                   ca_cache_timeout = CACacheTimeout,
-                  pipewait = Pipewait}) ->
+                  pipewait = Pipewait,
+                  stream = Stream}) ->
     Opts = [{?CONNECTTIMEOUT_MS, ConnTimeoutMs},
             {?FOLLOWLOCATION, FollowLocation},
             {?SSL_VERIFYHOST, SslVerifyHost},
@@ -253,7 +291,8 @@ send_to_port(Port, {Self, Ref},
             {?USERPWD, UserPwd},
             {?DNS_CACHE_TIMEOUT, DNSCacheTimeout},
             {?CA_CACHE_TIMEOUT, CACacheTimeout},
-            {?PIPEWAIT, Pipewait}],
+            {?PIPEWAIT, Pipewait},
+            {?STREAM, Stream}],
     Command = {Self, Ref, Method, Url, Headers, CookieJar, Body, Opts},
     true = port_command(Port, term_to_binary(Command)).
 

--- a/src/katipo_worker.erl
+++ b/src/katipo_worker.erl
@@ -72,6 +72,16 @@ handle_cast({cancel, UserRef}, State = #state{port = Port, reqs = Reqs}) ->
     %% Broadcast reaches every worker; only the one holding this request acts.
     Reqs2 = cancel_async(Port, UserRef, Reqs),
     {noreply, State#state{reqs = Reqs2}};
+handle_cast({flow, UserRef, N}, State = #state{port = Port, reqs = Reqs}) ->
+    %% Broadcast, like cancel: grant N more chunk credits to the streaming
+    %% request with this user Ref, if this worker holds it.
+    _ = case find_async(UserRef, Reqs) of
+            {ok, {Self, Ref}, _Tref, _Obs} ->
+                port_cmd(Port, {Self, Ref, flow, N});
+            error ->
+                ok
+        end,
+    {noreply, State};
 handle_cast(Msg, State) ->
     logger:error("Unexpected cast: ~p", [Msg]),
     {noreply, State}.
@@ -211,12 +221,16 @@ cancel_async(Port, UserRef, Reqs) ->
     end.
 
 %% Ask the C port to abort the in-flight transfer identified by {Pid, Ref}
-%% (a no-op there if it already completed). Best-effort: port_command raises
-%% badarg if the port died and its 'EXIT' message is still queued behind us;
-%% the transfer is gone either way, and crashing here would let terminate/2
-%% message callers that have already been dealt with.
+%% (a no-op there if it already completed).
 abort_transfer(Port, {Pid, Ref}) ->
-    try port_command(Port, term_to_binary({Pid, Ref, cancel}))
+    port_cmd(Port, {Pid, Ref, cancel}).
+
+%% Best-effort port write: port_command raises badarg if the port died and
+%% its 'EXIT' message is still queued behind us; whatever we were telling the
+%% port is moot then, and crashing here would let terminate/2 message callers
+%% that have already been dealt with.
+port_cmd(Port, Tuple) ->
+    try port_command(Port, term_to_binary(Tuple))
     catch error:badarg -> ok
     end,
     ok.
@@ -264,7 +278,8 @@ send_to_port(Port, {Self, Ref},
                   dns_cache_timeout = DNSCacheTimeout,
                   ca_cache_timeout = CACacheTimeout,
                   pipewait = Pipewait,
-                  stream = Stream}) ->
+                  stream = Stream,
+                  stream_window = StreamWindow}) ->
     Opts = [{?CONNECTTIMEOUT_MS, ConnTimeoutMs},
             {?FOLLOWLOCATION, FollowLocation},
             {?SSL_VERIFYHOST, SslVerifyHost},
@@ -292,7 +307,8 @@ send_to_port(Port, {Self, Ref},
             {?DNS_CACHE_TIMEOUT, DNSCacheTimeout},
             {?CA_CACHE_TIMEOUT, CACacheTimeout},
             {?PIPEWAIT, Pipewait},
-            {?STREAM, Stream}],
+            {?STREAM, Stream},
+            {?STREAM_WINDOW, StreamWindow}],
     Command = {Self, Ref, Method, Url, Headers, CookieJar, Body, Opts},
     true = port_command(Port, term_to_binary(Command)).
 

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -168,7 +168,9 @@ groups() ->
        basic_authorised,
        digest_unauthorised,
        digest_authorised,
-       proxy_couldnt_connect]},
+       proxy_couldnt_connect,
+       streaming_response,
+       streaming_empty_body]},
      {curl, [parallel],
       [url_missing,
        bad_method,
@@ -255,7 +257,12 @@ groups() ->
        sync_worker_death,
        unknown_pool_not_worker_died,
        async_cancel,
-       async_cancel_after_complete]},
+       async_cancel_after_complete,
+       streaming_cancel,
+       streaming_timeout,
+       streaming_connect_error,
+       streaming_sync_rejected,
+       streaming_worker_death]},
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
@@ -1290,6 +1297,153 @@ repeat_until_true(Fun) ->
 httpbin_url(Config, Path) ->
     Base = ?config(httpbin_base, Config),
     <<Base/binary, Path/binary>>.
+
+%% -- streaming responses (stream => true) ---------------------------------
+
+%% Same deterministic /range content as bytes/stream_bytes, delivered as
+%% headers -> chunks -> done instead of one buffered body.
+streaming_response(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/range/1024?chunk_size=8">>),
+    {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url,
+                                              method => get,
+                                              stream => true}),
+    {200, Headers, Body} = collect_stream(Ref),
+    true = length(Headers) > 0,
+    1024 = byte_size(Body),
+    <<147,0,83,230,212,92,147,255,38,102,201,139,205,150,16,161>> =
+        crypto:hash(md5, Body).
+
+%% A bodyless response still delivers headers, then done, with no chunks.
+streaming_empty_body(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/status/204">>),
+    {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url,
+                                              method => get,
+                                              stream => true}),
+    {204, _Headers, <<>>} = collect_stream(Ref).
+
+%% Cancelling an in-flight streaming request stops delivery entirely: no
+%% headers, chunks, or terminal message ever arrive. (The local httpbin
+%% buffers responses, so a cancel between headers and done is not
+%% deterministically reachable here; cancel-before-response is.)
+streaming_cancel(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    PoolName = streaming_cancel_test,
+    {ok, _} = katipo_pool:start(PoolName, 1),
+    Url = httpbin_url(Config, <<"/delay/3">>),
+    {ok, Ref} = katipo:async_req(PoolName, Opts#{url => Url,
+                                                 method => get,
+                                                 stream => true}),
+    ok = wait_for_inflight(PoolName),
+    ok = katipo:cancel(PoolName, Ref),
+    ok = wait_for_no_inflight(PoolName),
+    %% Require silence well past the /delay/3 completion time.
+    ok = assert_stream_stopped(Ref, 4000),
+    katipo_pool:stop(PoolName).
+
+%% A timeout on a streaming request is delivered as the same terminal
+%% katipo_error as for buffered requests.
+streaming_timeout(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/delay/10">>),
+    {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url,
+                                              method => get,
+                                              stream => true,
+                                              timeout_ms => 1000}),
+    ok = expect_stream_error(Ref, operation_timedout, 10000).
+
+%% A connect failure before any response arrives delivers a single
+%% katipo_error and no headers.
+streaming_connect_error(_Config) ->
+    {ok, Ref} = katipo:async_req(?POOL, #{url => <<"http://192.0.2.1">>,
+                                          method => get,
+                                          stream => true,
+                                          connecttimeout_ms => 1,
+                                          timeout_ms => 2000}),
+    receive
+        {katipo_error, Ref, #{code := operation_timedout}} -> ok;
+        {katipo_headers, Ref, Headers} -> ct:fail({unexpected_headers, Headers})
+    after 10000 ->
+            ct:fail(no_error)
+    end.
+
+%% Streaming has no meaning for the synchronous API.
+streaming_sync_rejected(_Config) ->
+    {error, #{code := bad_opts}} =
+        katipo:get(?POOL, <<"http://192.0.2.1">>, #{stream => true}).
+
+%% Worker death mid-stream delivers the same prompt terminal worker_died
+%% as it does for buffered async requests.
+streaming_worker_death(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    PoolName = streaming_worker_death_test,
+    {ok, _} = katipo_pool:start(PoolName, 1),
+    Url = httpbin_url(Config, <<"/delay/5">>),
+    {ok, Ref} = katipo:async_req(PoolName, Opts#{url => Url,
+                                                 method => get,
+                                                 stream => true}),
+    ok = wait_for_inflight(PoolName),
+    _ = kill_worker_port(PoolName),
+    receive
+        {katipo_error, Ref, #{code := worker_died}} -> ok
+    after 5000 ->
+            ct:fail(no_worker_died)
+    end,
+    ok = katipo_pool:stop(PoolName).
+
+%% Collect one full stream: headers, any chunks, then done. Errors and
+%% out-of-order messages fail the test.
+collect_stream(Ref) ->
+    receive
+        {katipo_headers, Ref, #{status := Status, headers := Headers}} ->
+            collect_chunks(Ref, Status, Headers, [])
+    after 10000 ->
+            ct:fail(no_stream_headers)
+    end.
+
+collect_chunks(Ref, Status, Headers, Acc) ->
+    receive
+        {katipo_chunk, Ref, Bin} ->
+            collect_chunks(Ref, Status, Headers, [Bin | Acc]);
+        {katipo_done, Ref, #{status := Status}} ->
+            {Status, Headers, iolist_to_binary(lists:reverse(Acc))};
+        {katipo_error, Ref, Error} ->
+            ct:fail({stream_error, Error})
+    after 10000 ->
+            ct:fail(stream_stalled)
+    end.
+
+%% Require complete silence for the cancelled stream: no headers, chunks,
+%% or terminal message.
+assert_stream_stopped(Ref, Timeout) ->
+    receive
+        {katipo_headers, Ref, Headers} ->
+            ct:fail({headers_after_cancel, Headers});
+        {katipo_chunk, Ref, _} ->
+            ct:fail(chunk_after_cancel);
+        {katipo_done, Ref, Done} ->
+            ct:fail({done_after_cancel, Done});
+        {katipo_error, Ref, Error} ->
+            ct:fail({error_after_cancel, Error})
+    after Timeout ->
+            ok
+    end.
+
+%% Drain headers/chunks until the expected terminal error arrives.
+expect_stream_error(Ref, Code, Timeout) ->
+    receive
+        {katipo_headers, Ref, _} ->
+            expect_stream_error(Ref, Code, Timeout);
+        {katipo_chunk, Ref, _} ->
+            expect_stream_error(Ref, Code, Timeout);
+        {katipo_error, Ref, #{code := Code}} ->
+            ok;
+        {katipo_done, Ref, Done} ->
+            ct:fail({unexpected_done, Done})
+    after Timeout ->
+            ct:fail(no_stream_error)
+    end.
 
 %% OpenTelemetry integration tests
 

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -170,7 +170,8 @@ groups() ->
        digest_authorised,
        proxy_couldnt_connect,
        streaming_response,
-       streaming_empty_body]},
+       streaming_empty_body,
+       streaming_flow_control]},
      {curl, [parallel],
       [url_missing,
        bad_method,
@@ -262,7 +263,9 @@ groups() ->
        streaming_timeout,
        streaming_connect_error,
        streaming_sync_rejected,
-       streaming_worker_death]},
+       streaming_window_invalid,
+       streaming_worker_death,
+       streaming_flow_starvation]},
      {otel, [],
       [otel_span_created,
        otel_metrics_recorded,
@@ -1314,6 +1317,60 @@ streaming_response(Config) ->
     <<147,0,83,230,212,92,147,255,38,102,201,139,205,150,16,161>> =
         crypto:hash(md5, Body).
 
+%% stream_window => 1 delivers exactly one chunk then pauses the transfer
+%% (client-side, so independent of server pacing) until update_flow/3
+%% grants another credit; the reassembled body must still be complete.
+streaming_flow_control(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/range/65536">>),
+    {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url,
+                                              method => get,
+                                              stream => true,
+                                              stream_window => 1}),
+    receive
+        {katipo_headers, Ref, #{status := 200}} -> ok
+    after 10000 ->
+            ct:fail(no_headers)
+    end,
+    %% The 64k body spans several curl write buffers, so with one credit
+    %% exactly one chunk arrives and the transfer pauses.
+    Chunk1 = receive
+                 {katipo_chunk, Ref, C} -> C
+             after 10000 ->
+                     ct:fail(no_first_chunk)
+             end,
+    receive
+        {katipo_chunk, Ref, _} -> ct:fail(chunk_beyond_window);
+        {katipo_done, Ref, Done} -> ct:fail({done_beyond_window, Done})
+    after 500 ->
+            ok
+    end,
+    Body = collect_with_credits(Ref, [Chunk1]),
+    65536 = byte_size(Body),
+    <<186,131,222,164,69,192,190,233,191,135,112,45,73,76,148,71>> =
+        crypto:hash(md5, Body),
+    %% Granting credits to an unknown Ref is a harmless no-op.
+    ok = katipo:update_flow(?POOL, make_ref(), 1).
+
+collect_with_credits(Ref, Acc) ->
+    ok = katipo:update_flow(?POOL, Ref, 1),
+    receive
+        {katipo_chunk, Ref, Bin} ->
+            collect_with_credits(Ref, [Bin | Acc]);
+        {katipo_done, Ref, #{status := 200}} ->
+            iolist_to_binary(lists:reverse(Acc));
+        {katipo_error, Ref, Error} ->
+            ct:fail({stream_error, Error})
+    after 10000 ->
+            ct:fail(stream_stalled_with_credits)
+    end.
+
+%% stream_window must be a positive integer or infinity.
+streaming_window_invalid(_Config) ->
+    {error, #{code := bad_opts}} =
+        katipo:async_get(?POOL, <<"http://192.0.2.1">>,
+                         #{stream => true, stream_window => 0}).
+
 %% A bodyless response still delivers headers, then done, with no chunks.
 streaming_empty_body(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
@@ -1372,6 +1429,21 @@ streaming_connect_error(_Config) ->
 streaming_sync_rejected(_Config) ->
     {error, #{code := bad_opts}} =
         katipo:get(?POOL, <<"http://192.0.2.1">>, #{stream => true}).
+
+%% The request timer keeps running while a transfer is paused awaiting
+%% credits: a consumer that stops granting eventually gets the same
+%% terminal operation_timedout as any stalled request. Both curl-side and
+%% Erlang-side timers are capped so whichever fires first ends the test.
+streaming_flow_starvation(Config) ->
+    {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
+    Url = httpbin_url(Config, <<"/range/65536">>),
+    {ok, Ref} = katipo:async_req(?POOL, Opts#{url => Url,
+                                              method => get,
+                                              stream => true,
+                                              stream_window => 1,
+                                              connecttimeout_ms => 1500,
+                                              timeout_ms => 1500}),
+    ok = expect_stream_error(Ref, operation_timedout, 10000).
 
 %% Worker death mid-stream delivers the same prompt terminal worker_died
 %% as it does for buffered async requests.

--- a/test/katipo_SUITE.erl
+++ b/test/katipo_SUITE.erl
@@ -8,6 +8,10 @@
 -include_lib("opentelemetry/include/otel_span.hrl").
 
 -define(POOL, katipo_test_pool).
+%% MD5 of /range/1024: 1024 bytes of repeating a-z (deterministic content,
+%% unlike /bytes whose seeded RNG is shared server-global state).
+-define(RANGE_1024_MD5,
+        <<147,0,83,230,212,92,147,255,38,102,201,139,205,150,16,161>>).
 -define(POOL_SIZE, 2).
 
 %% Wire-protocol constants for the malformed_requests group, mirroring the
@@ -541,13 +545,13 @@ bytes(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
     {ok, #{status := 200, body := Body}} = katipo:get(?POOL, httpbin_url(Config, <<"/range/1024">>), Opts),
     1024 = byte_size(Body),
-    <<147,0,83,230,212,92,147,255,38,102,201,139,205,150,16,161>> = crypto:hash(md5, Body).
+    ?RANGE_1024_MD5 = crypto:hash(md5, Body).
 
 stream_bytes(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
     {ok, #{status := 200, body := Body}} = katipo:get(?POOL, httpbin_url(Config, <<"/range/1024?chunk_size=8">>), Opts),
     1024 = byte_size(Body),
-    <<147,0,83,230,212,92,147,255,38,102,201,139,205,150,16,161>> = crypto:hash(md5, Body).
+    ?RANGE_1024_MD5 = crypto:hash(md5, Body).
 
 utf8(Config) ->
     {req_opts, Opts} = lists:keyfind(req_opts, 1, Config),
@@ -1314,8 +1318,7 @@ streaming_response(Config) ->
     {200, Headers, Body} = collect_stream(Ref),
     true = length(Headers) > 0,
     1024 = byte_size(Body),
-    <<147,0,83,230,212,92,147,255,38,102,201,139,205,150,16,161>> =
-        crypto:hash(md5, Body).
+    ?RANGE_1024_MD5 = crypto:hash(md5, Body).
 
 %% stream_window => 1 delivers exactly one chunk then pauses the transfer
 %% (client-side, so independent of server pacing) until update_flow/3
@@ -1345,31 +1348,29 @@ streaming_flow_control(Config) ->
     after 500 ->
             ok
     end,
-    Body = collect_with_credits(Ref, [Chunk1]),
+    Grant = fun() -> katipo:update_flow(?POOL, Ref, 1) end,
+    {200, [], Body} = collect_chunks(Ref, 200, [], Grant, [Chunk1]),
     65536 = byte_size(Body),
     <<186,131,222,164,69,192,190,233,191,135,112,45,73,76,148,71>> =
         crypto:hash(md5, Body),
     %% Granting credits to an unknown Ref is a harmless no-op.
     ok = katipo:update_flow(?POOL, make_ref(), 1).
 
-collect_with_credits(Ref, Acc) ->
-    ok = katipo:update_flow(?POOL, Ref, 1),
-    receive
-        {katipo_chunk, Ref, Bin} ->
-            collect_with_credits(Ref, [Bin | Acc]);
-        {katipo_done, Ref, #{status := 200}} ->
-            iolist_to_binary(lists:reverse(Acc));
-        {katipo_error, Ref, Error} ->
-            ct:fail({stream_error, Error})
-    after 10000 ->
-            ct:fail(stream_stalled_with_credits)
-    end.
-
-%% stream_window must be a positive integer or infinity.
+%% stream_window must be a positive integer or infinity, and only means
+%% something on a streaming request.
 streaming_window_invalid(_Config) ->
     {error, #{code := bad_opts}} =
         katipo:async_get(?POOL, <<"http://192.0.2.1">>,
-                         #{stream => true, stream_window => 0}).
+                         #{stream => true, stream_window => 0}),
+    {error, #{code := bad_opts}} =
+        katipo:async_get(?POOL, <<"http://192.0.2.1">>,
+                         #{stream_window => 4}),
+    %% check_opts agrees with the request entry points on cross-field rules.
+    {error, #{code := bad_opts}} = katipo:check_opts(#{url => <<"http://x">>,
+                                                       stream_window => 4}),
+    ok = katipo:check_opts(#{url => <<"http://x">>,
+                             stream => true,
+                             stream_window => 4}).
 
 %% A bodyless response still delivers headers, then done, with no chunks.
 streaming_empty_body(Config) ->
@@ -1469,15 +1470,18 @@ streaming_worker_death(Config) ->
 collect_stream(Ref) ->
     receive
         {katipo_headers, Ref, #{status := Status, headers := Headers}} ->
-            collect_chunks(Ref, Status, Headers, [])
+            collect_chunks(Ref, Status, Headers, fun() -> ok end, [])
     after 10000 ->
             ct:fail(no_stream_headers)
     end.
 
-collect_chunks(Ref, Status, Headers, Acc) ->
+%% Grant runs before every receive: fun() -> ok end for unbounded streams,
+%% or an update_flow call when driving a bounded stream_window.
+collect_chunks(Ref, Status, Headers, Grant, Acc) ->
+    ok = Grant(),
     receive
         {katipo_chunk, Ref, Bin} ->
-            collect_chunks(Ref, Status, Headers, [Bin | Acc]);
+            collect_chunks(Ref, Status, Headers, Grant, [Bin | Acc]);
         {katipo_done, Ref, #{status := Status}} ->
             {Status, Headers, iolist_to_binary(lists:reverse(Acc))};
         {katipo_error, Ref, Error} ->


### PR DESCRIPTION
Adds streaming response delivery to the async API, replacing the whole-body buffering that costs roughly twice the body size in peak memory across the port boundary for large downloads. With stream => true on any async function the C port forwards body bytes as they arrive: {katipo_headers, Ref, _} once, {katipo_chunk, Ref, Bin} zero or more times in order, then a terminal {katipo_done, Ref, _}. A {katipo_error, Ref, _} stays terminal and can arrive at any point, including mid-body. cancel/2, request timers, and worker-death handling behave exactly as for buffered async requests, and the sync API rejects the option since there is no single response to return.

Flow control follows Gun's credit-window design rather than the per-chunk stream_next pull of hackney/ibrowse/httpc (which would cost a caller-to-worker-to-port round-trip per 16KB buffer): stream_window => N starts the transfer with N chunk-message credits and katipo:update_flow/3 grants more in batches, routed like cancel/2. At zero credits the C write callback returns CURL_WRITEFUNC_PAUSE, so curl stops reading the socket and backpressure genuinely reaches the server through TCP or the HTTP/2/3 stream window. The window defaults to infinity, counts messages (bounding consumer exposure to roughly N × 16KB), and the request timer keeps running while paused, so a consumer that stops granting credits eventually receives operation_timedout. Setting stream_window without stream => true is rejected rather than silently ignored.

The chunk path is allocation-light: the 16KB payload is written to the pipe straight from curl's buffer, with only the small ei-encoded message prefix built per chunk. The TLA+ model gains bounded streaming progress messages and a NoProgressAfterStop invariant (no progress message reaches a caller after cancel or terminal resolution), verified over 1.09M states; the model header documents why credit gating preserves the verified properties by construction. Tests cover full-body reassembly against a deterministic hash across the protocol groups, bodyless responses, cancel, timeout, connect errors, option validation, and an end-to-end pause/resume test proving exactly one chunk arrives on a window of 1 until credits are granted.

This is stacked on #180 (abort-transfer-on-timeout) because a streaming timeout wants the port-side abort; only the three streaming commits are new here. It also supersedes #174 — this implementation adds flow control, model coverage, and the admission-handshake delivery guarantees that landed in #178 since that PR was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf2gxZLpxT4HvBfZKCgP3g
