### PR TITLE
perf: route cancel and flow commands via request aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project are documented here. This project follows
 - Development and CI now build and test against the current dependency
   versions within the published ranges: `worker_pool` 6.5.3 and
   `opentelemetry_api` 1.5.0 (previously locked to 6.0.1 and 1.4.0).
+- `cancel/2` and `update_flow/3` now route directly to the worker holding
+  the request: the returned `Ref` is a process alias, so commands are a
+  single O(1) send instead of a broadcast to every pool worker (each of
+  which scanned its request table). The pool argument is retained for API
+  compatibility and no longer used; late or unknown-Ref commands are
+  dropped by the runtime, preserving the best-effort no-op contract.
 
 ### Added
 - Streaming responses: pass `stream => true` to any async function to

--- a/README.md
+++ b/README.md
@@ -149,8 +149,11 @@ end.
 ```
 
 `await/1,2` blocks for that message (default 30s), and `cancel/2` aborts an
-in-flight request (best-effort). The message goes to the calling process by
-default; set the `reply_to` option to redirect it to another process. If the
+in-flight request (best-effort). The pool argument to `cancel/2` and
+`update_flow/3` is retained for compatibility and ignored — the `Ref` itself
+routes to the worker holding the request. The message goes to the calling
+process by default; set the `reply_to` option to redirect it to another
+process. If the
 worker's port dies while a request is in flight, both sync and async callers
 receive `{error, #{code => worker_died}}`; if an async request cannot be
 handed to a worker at all (it died and is being restarted), `async_req` itself

--- a/formal/KatipoFixed.tla
+++ b/formal/KatipoFixed.tla
@@ -6,9 +6,10 @@
 (*     caller's monitor converts every dispatch failure -- dead/restarting *)
 (*     worker name, call lost in a crashing worker's mailbox, badarg crash *)
 (*     in send_to_port -- into an immediate {error, worker_died} return.   *)
-(*  2. cancel_async removes the request from Reqs BEFORE port_command and  *)
-(*     swallows badarg, so a cancel against a dead port neither crashes    *)
-(*     the worker nor lets terminate/2 message a cancelled caller.         *)
+(*  2. the cancel handler removes the request from Reqs and only then      *)
+(*     writes the best-effort port abort (badarg swallowed), so a cancel   *)
+(*     against a dead port neither crashes the worker nor lets             *)
+(*     terminate/2 message a cancelled caller.                             *)
 (*                                                                         *)
 (* delivered[r] counts terminal outcomes for r: an async message from the  *)
 (* worker OR an {error, worker_died} return from async_req itself.         *)
@@ -104,8 +105,10 @@ SendAsync(r) ==
   /\ UNCHANGED <<wAlive, pAlive, pQ, reqs, timerFired, conns, cancelled,
                  effCancel, effCancelSnap, deaths, cancelPollution, chunksEmitted, progressStop>>
 
-\* katipo:cancel/2 -> wpool:broadcast: still a cast, dropped if dead. Only
-\* refs whose admission call returned {ok, Ref} can be cancelled.
+\* katipo:cancel/2: a direct send to the request's alias Ref, delivered
+\* iff the owning worker is alive (the alias dies with it -- same drop
+\* semantics the old broadcast-cast had). Only refs whose admission call
+\* returned {ok, Ref} can be cancelled.
 SendCancel(r) ==
   /\ r \in sent /\ r \notin cancelled
   /\ r \notin QueuedCalls(wQ)  \* async_req has returned
@@ -141,9 +144,10 @@ WorkerRecvReq(r) ==
 \* cancel and timeout paths, mirroring the code's shared helper.
 AbortPQ(r) == IF pAlive THEN Append(pQ, CancelMsg(r)) ELSE pQ
 
-\* handle_cast({cancel, Ref}) -> cancel_async (FIXED): cancel_timer, then
-\* maps:remove, then abort_transfer. The worker survives a cancel against a
-\* dead port and the request is out of Reqs either way.
+\* handle_info({cancel, Ref}) (sent to the request's alias): cancel_timer,
+\* remove from Reqs, deactivate the alias, then abort_transfer. The worker
+\* survives a cancel against a dead port and the request is out of Reqs
+\* either way.
 WorkerRecvCancel(r) ==
   /\ wAlive /\ wQ # <<>> /\ Head(wQ) = CancelMsg(r)
   /\ wQ' = Tail(wQ)

--- a/src/katipo.erl
+++ b/src/katipo.erl
@@ -337,10 +337,9 @@ async_req(PoolName, Opts)
         true ->
             case katipo_req:build_req(Opts2, async) of
                 {ok, Req} ->
-                    UserRef = make_ref(),
                     Obs = katipo_span:start_async(katipo_req:method_int_to_binary(Req#req.method),
                                                   Req#req.url),
-                    dispatch_async(PoolName, ReplyTo, UserRef, Req, Obs);
+                    dispatch_async(PoolName, ReplyTo, Req, Obs);
                 {error, _} = Error ->
                     Error
             end
@@ -350,10 +349,12 @@ async_req(PoolName, Opts)
 %% immediately instead of losing the request: a cast to a dead or restarting
 %% worker name is silently dropped, and a worker that crashes on port_command
 %% before registering the request can notify nobody afterwards. pool_call/2
-%% turns both into an immediate {error, worker_died} return.
-dispatch_async(PoolName, ReplyTo, UserRef, Req, Obs) ->
-    case pool_call(PoolName, {async_req, ReplyTo, UserRef, Req, Obs}) of
-        {ok, ok} ->
+%% turns both into an immediate {error, worker_died} return. The returned
+%% Ref is worker-minted (a process alias; see the worker's admission clause
+%% for the full lifecycle).
+dispatch_async(PoolName, ReplyTo, Req, Obs) ->
+    case pool_call(PoolName, {async_req, ReplyTo, Req, Obs}) of
+        {ok, UserRef} when is_reference(UserRef) ->
             {ok, UserRef};
         {error, Error} ->
             katipo_span:finish_async(Obs, error, Error, []),
@@ -362,14 +363,16 @@ dispatch_async(PoolName, ReplyTo, UserRef, Req, Obs) ->
 
 -doc """
 Grants `N` more chunk-message credits to the streaming request `Ref`, which
-must have been started with a bounded `stream_window`. Best-effort like
-`cancel/2`: granting credits to an unknown, completed, or unbounded-window
-request is a harmless no-op. Each grant is a pool-wide broadcast, so grant
-in batches (e.g. half the window at a time) rather than per-chunk.
+must have been started with a bounded `stream_window`. Routed like
+`cancel/2` (directly to the owning worker; the pool argument is unused) and
+equally best-effort: granting credits to an unknown, completed, or
+unbounded-window request is a harmless no-op. Granting in batches (e.g.
+half the window at a time) amortizes the per-grant messaging.
 """.
 -spec update_flow(katipo_pool:name(), reference(), pos_integer()) -> ok.
-update_flow(PoolName, Ref, N) when is_integer(N) andalso N > 0 ->
-    wpool:broadcast(PoolName, {flow, Ref, N}),
+update_flow(_PoolName, Ref, N) when is_reference(Ref) andalso
+                                    is_integer(N) andalso N > 0 ->
+    Ref ! {flow, Ref, N},
     ok.
 
 -doc #{equiv => await/2}.
@@ -398,20 +401,18 @@ await(Ref, Timeout) ->
 
 -doc """
 Cancels the async request identified by `Ref` (returned by `async_get/2,3`,
-`async_req/2`, etc.).
+`async_req/2`, etc.). The `Ref` routes directly to the worker holding the
+request; the pool argument is retained for API compatibility and not used.
 
 Best-effort: once the cancel takes effect no `{katipo_response, Ref, _}` or
 `{katipo_error, Ref, _}` message is delivered. A message that was already
 delivered before the cancel raced in may still be in the receiver's mailbox, so
 callers should be prepared to flush a late one. Cancelling an unknown or
 already-completed `Ref` is a harmless no-op.
-
-Note: the in-flight HTTP transfer is not aborted — it completes in the
-background and its result is discarded.
 """.
 -spec cancel(katipo_pool:name(), reference()) -> ok.
-cancel(PoolName, Ref) ->
-    wpool:broadcast(PoolName, {cancel, Ref}),
+cancel(_PoolName, Ref) when is_reference(Ref) ->
+    Ref ! {cancel, Ref},
     ok.
 
 -doc false.

--- a/src/katipo_worker.erl
+++ b/src/katipo_worker.erl
@@ -50,9 +50,16 @@ init([CurlOpts]) ->
 
 handle_call(Req = #req{}, From, State) ->
     {noreply, admit(From, sync, Req, State)};
-handle_call({async_req, ReplyTo, UserRef, Req = #req{}, Obs}, _From, State) ->
-    State2 = admit({self(), make_ref()}, {async, ReplyTo, UserRef, Obs}, Req, State),
-    {reply, ok, State2}.
+handle_call({async_req, ReplyTo, Req = #req{}, Obs}, _From, State) ->
+    %% The user-facing Ref is a process alias, so cancel/flow commands are
+    %% plain sends to the Ref itself: they route straight to this worker,
+    %% and once the alias dies (with us) or is deactivated (on resolution)
+    %% the runtime drops them -- the documented best-effort no-op. Doubling
+    %% it as the ref in the port identity makes command handling a direct
+    %% map lookup on {self(), Ref}.
+    Alias = alias(),
+    State2 = admit({self(), Alias}, {async, ReplyTo, Obs}, Req, State),
+    {reply, Alias, State2}.
 
 %% Register a request: hand it to the port, arm its timer, record it in Reqs.
 %% send_to_port runs BEFORE the Reqs insert on purpose: if the port is
@@ -68,20 +75,6 @@ admit(From, Kind, Req = #req{timeout = Timeout},
     Tref = erlang:start_timer(Timeout, self(), {req_timeout, From}),
     State#state{reqs = Reqs#{From => {Tref, Kind}}}.
 
-handle_cast({cancel, UserRef}, State = #state{port = Port, reqs = Reqs}) ->
-    %% Broadcast reaches every worker; only the one holding this request acts.
-    Reqs2 = cancel_async(Port, UserRef, Reqs),
-    {noreply, State#state{reqs = Reqs2}};
-handle_cast({flow, UserRef, N}, State = #state{port = Port, reqs = Reqs}) ->
-    %% Broadcast, like cancel: grant N more chunk credits to the streaming
-    %% request with this user Ref, if this worker holds it.
-    _ = case find_async(UserRef, Reqs) of
-            {ok, {Self, Ref}, _Tref, _Obs} ->
-                port_cmd(Port, {Self, Ref, flow, N});
-            error ->
-                ok
-        end,
-    {noreply, State};
 handle_cast(Msg, State) ->
     logger:error("Unexpected cast: ~p", [Msg]),
     {noreply, State}.
@@ -119,9 +112,9 @@ handle_port_msg({done, {From, {Status, CookieJar, Metrics}}}, Reqs) ->
 %% in flight; otherwise they are dropped silently (the request timed out,
 %% was cancelled, or already completed). The message is only built when it
 %% will be sent.
-forward_progress(From, Reqs, BuildMsg) ->
+forward_progress(From = {_Self, UserRef}, Reqs, BuildMsg) ->
     _ = case maps:find(From, Reqs) of
-            {ok, {_Tref, {async, ReplyTo, UserRef, _Obs}}} ->
+            {ok, {_Tref, {async, ReplyTo, _Obs}}} ->
                 ReplyTo ! BuildMsg(UserRef);
             _ ->
                 ok
@@ -130,25 +123,35 @@ forward_progress(From, Reqs, BuildMsg) ->
 
 %% Resolve a request with its terminal result, if it is still in flight.
 finish_req(From, Result, Response, Reqs) ->
-    _ = case maps:find(From, Reqs) of
-            {ok, {Tref, Kind}} ->
-                _ = erlang:cancel_timer(Tref),
-                deliver(Kind, From, Result, Response);
-            error ->
-                ok
-        end,
-    maps:remove(From, Reqs).
+    case maps:take(From, Reqs) of
+        {{Tref, Kind}, Rest} ->
+            _ = erlang:cancel_timer(Tref),
+            deliver(Kind, From, Result, Response),
+            deactivate(From, Kind),
+            Rest;
+        error ->
+            Reqs
+    end.
+
+%% Deactivate a resolved async request's alias (the ref in its From key) so
+%% late cancel/flow sends are dropped by the runtime instead of landing in
+%% our mailbox.
+deactivate({_Self, Alias}, {async, _ReplyTo, _Obs}) ->
+    _ = unalias(Alias),
+    ok;
+deactivate(_From, sync) ->
+    ok.
 
 %% Deliver a terminal outcome to a sync caller (via gen_server:reply) or an
 %% async ReplyTo (via a flattened katipo_response/katipo_error/katipo_done
 %% message). `done` only occurs for streaming requests, which are async by
 %% construction.
-deliver({async, ReplyTo, UserRef, Obs}, _From, done, {DoneMap, Metrics}) ->
+deliver({async, ReplyTo, Obs}, {_Self, UserRef}, done, {DoneMap, Metrics}) ->
     ReplyTo ! {katipo_done, UserRef, DoneMap},
     katipo_span:finish_async(Obs, ok, DoneMap, Metrics);
 deliver(sync, From, Result, Response) ->
     gen_server:reply(From, {Result, Response});
-deliver({async, ReplyTo, UserRef, Obs}, _From, Result, {ResponseMap, Metrics}) ->
+deliver({async, ReplyTo, Obs}, {_Self, UserRef}, Result, {ResponseMap, Metrics}) ->
     Tag = case Result of ok -> katipo_response; error -> katipo_error end,
     ReplyTo ! {Tag, UserRef, ResponseMap},
     katipo_span:finish_async(Obs, Result, ResponseMap, Metrics).
@@ -161,7 +164,7 @@ deliver_timeout(Kind, From) ->
 %% reply_to (as a katipo_error message).
 deliver_error(sync, From, Error) ->
     gen_server:reply(From, {error, {Error, []}});
-deliver_error({async, ReplyTo, UserRef, Obs}, _From, Error) ->
+deliver_error({async, ReplyTo, Obs}, {_Self, UserRef}, Error) ->
     ReplyTo ! {katipo_error, UserRef, Error},
     katipo_span:finish_async(Obs, error, Error, []).
 
@@ -171,18 +174,44 @@ handle_info({Port, {data, Data}}, State = #state{port = Port, reqs = Reqs}) ->
 handle_info({timeout, Tref, {req_timeout, From}},
             State = #state{port = Port, reqs = Reqs}) ->
     Reqs2 =
-        case maps:find(From, Reqs) of
-            {ok, {Tref, Kind}} ->
+        case maps:take(From, Reqs) of
+            {{Tref, Kind}, Rest} ->
                 _ = deliver_timeout(Kind, From),
+                deactivate(From, Kind),
                 %% Abort the transfer still running in the C port: its
                 %% eventual output would be dropped anyway now that the
                 %% request is out of Reqs.
                 abort_transfer(Port, From),
-                maps:remove(From, Reqs);
-            _ ->
+                Rest;
+            error ->
                 Reqs
         end,
     {noreply, State#state{reqs = Reqs2}};
+handle_info({cancel, Ref}, State = #state{port = Port, reqs = Reqs}) ->
+    %% Sent directly to the request's alias by katipo:cancel/2; a stale or
+    %% foreign Ref cannot match a live entry. Async entries are keyed by
+    %% {self(), Alias}, so this is a straight lookup.
+    From = {self(), Ref},
+    Reqs2 =
+        case maps:take(From, Reqs) of
+            {{Tref, Kind = {async, _ReplyTo, Obs}}, Rest} ->
+                _ = erlang:cancel_timer(Tref),
+                deactivate(From, Kind),
+                abort_transfer(Port, From),
+                katipo_span:end_async(Obs),
+                Rest;
+            error ->
+                Reqs
+        end,
+    {noreply, State#state{reqs = Reqs2}};
+handle_info({flow, Ref, N}, State = #state{port = Port, reqs = Reqs}) ->
+    %% Sent directly to the request's alias by katipo:update_flow/3.
+    From = {Self = self(), Ref},
+    _ = case is_map_key(From, Reqs) of
+            true -> port_cmd(Port, {Self, Ref, flow, N});
+            false -> ok
+        end,
+    {noreply, State};
 handle_info({'EXIT', Port, Reason}, State = #state{port = Port}) ->
     logger:error("Port ~p died with reason: ~p", [Port, Reason]),
     {stop, port_died, State}.
@@ -202,25 +231,10 @@ terminate(_Reason, #state{port = Port, reqs = Reqs}) ->
     end,
     ok.
 
-notify_worker_died(From, {_Tref, {async, _, _, _} = Kind}) ->
+notify_worker_died(From, {_Tref, {async, _, _} = Kind}) ->
     deliver_error(Kind, From, katipo_req:error_map(worker_died, <<>>));
 notify_worker_died(_From, {_Tref, sync}) ->
     ok.
-
-%% Cancel the async request with this user Ref, if this worker holds it: tell
-%% the port to abort the transfer, cancel the timer, and drop the reqs entry so
-%% no response is delivered.
-cancel_async(Port, UserRef, Reqs) ->
-    case find_async(UserRef, Reqs) of
-        {ok, From, Tref, Obs} ->
-            _ = erlang:cancel_timer(Tref),
-            Reqs2 = maps:remove(From, Reqs),
-            abort_transfer(Port, From),
-            katipo_span:end_async(Obs),
-            Reqs2;
-        error ->
-            Reqs
-    end.
 
 %% Ask the C port to abort the in-flight transfer identified by {Pid, Ref}
 %% (a no-op there if it already completed).
@@ -236,19 +250,6 @@ port_cmd(Port, Tuple) ->
     catch error:badarg -> ok
     end,
     ok.
-
-find_async(UserRef, Reqs) ->
-    find_async_iter(UserRef, maps:iterator(Reqs)).
-
-find_async_iter(UserRef, Iter) ->
-    case maps:next(Iter) of
-        {From, {Tref, {async, _ReplyTo, UserRef, Obs}}, _Rest} ->
-            {ok, From, Tref, Obs};
-        {_From, _Value, Rest} ->
-            find_async_iter(UserRef, Rest);
-        none ->
-            error
-    end.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.


### PR DESCRIPTION
cancel/2 and update_flow/3 were pool-wide broadcasts, with every worker scanning its whole request table for the Ref — N−1 workers doing pure waste per cancel and per credit grant, which matters now that flow grants run per window batch on streaming transfers.

This routes commands directly using the BEAM's process aliases: the worker mints the user-facing Ref with erlang:alias/0 during the admission call, so both commands become a single send to the Ref itself. The runtime's alias semantics supply the documented best-effort contract for free — the alias dies with the worker, is deactivated when the request resolves, and sends to a dead, deactivated, or unknown Ref are silently dropped, so "cancelling an unknown or completed Ref is a harmless no-op" holds with zero defensive code. The alias doubles as the ref in the port-side {Pid, Ref} identity, making command handling a direct map lookup; find_async's linear scan and cancel_async are deleted outright, and the async Kind tuple no longer carries a user-ref field since it's derivable from the Reqs key. The C protocol is untouched (an alias is an ordinary reference on the wire), public types are unchanged, and the pool argument to both functions is retained for API compatibility but no longer load-bearing — which also removes the wrong-pool-name footgun.

All 196 tests pass unchanged, meaning every existing cancel and flow test transparently exercises the new path; dialyzer, xref, and lint are clean. The TLA+ model needed only comment updates: its cancel action already had exactly these drop semantics.

Stacked on #182 (streaming responses), which is stacked on #180 — merge in that order; I'll rebase each layer as the one below lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf2gxZLpxT4HvBfZKCgP3g
